### PR TITLE
Allow move assignment of AFF4ScopedPtr

### DIFF
--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -256,6 +256,15 @@ class AFF4ScopedPtr {
         resolver_ = other.resolver_;
     }
 
+    AFF4ScopedPtr& operator=(AFF4ScopedPtr&& other) {
+        if (this != *other) {
+            this->~AFF4ScopedPtr();
+            new (this) AFF4ScopedPtr(std::forward<AFF4ScopedPtr>(other));
+        }
+
+        return (*this);
+    }
+
     AFF4ScopedPtr(const AFF4ScopedPtr& other) = delete;
     void operator=(const AFF4ScopedPtr& other) = delete;
 };

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -257,7 +257,7 @@ class AFF4ScopedPtr {
     }
 
     AFF4ScopedPtr& operator=(AFF4ScopedPtr&& other) {
-        if (this != *other) {
+        if (this != &other) {
             this->~AFF4ScopedPtr();
             new (this) AFF4ScopedPtr(std::forward<AFF4ScopedPtr>(other));
         }


### PR DESCRIPTION
This patch allows AFF4ScopedPtrs to be move assigned.