### PR TITLE
On windows STDOUT needs to be changed to binary mode.

### DIFF
--- a/README.windows
+++ b/README.windows
@@ -34,7 +34,7 @@ make -j4 install
 cd ..
 
 apt-get source libtclap-dev
-cd tclap-1.2.1/
+cd tclap-1.2.2/
 ./configure --prefix=$PREFIX --enable-static LDFLAGS="-L$PREFIX/lib -static -static-libstdc++" --host=i686-w64-mingw32 \
     CXXFLAGS="-static -mnop-fun-dllimport -DPCRE_STATIC"
 make -j4 install

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -420,10 +420,19 @@ AFF4Status AFF4BuiltInStreams::LoadFromURN() {
 
     // Right now we only support writing to stdout.
     if (type == "stdout") {
-        fd = STDOUT_FILENO;
         properties.seekable = false;
         properties.writable = true;
         properties.sizeable = false;
+
+#ifdef _WIN32
+        // On windows stdout is set to text mode, we need to force it
+        // to binary mode or else it will corrupt the output (issue
+        // #31)
+        fd = _fileno( stdout );
+        _setmode (fd, _O_BINARY);
+#else
+        fd = STDOUT_FILENO;
+#endif
 
         return STATUS_OK;
     }


### PR DESCRIPTION
This fixes issue #31 - corrupted output when redirecting output on
windows.