### PR TITLE
Support for VSM.

### DIFF
--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -211,8 +211,31 @@ std::string FileBackedObject::Read(size_t length) {
     return std::string(result.get(), buffer_size);
 }
 
+AFF4Status FileBackedObject::ReadBuffer(char* data, size_t *length) {
+    DWORD buf_length = (DWORD)*length;
 
-AFF4Status FileBackedObject::Write(const char* data, int length) {
+    if (properties.seekable) {
+        LARGE_INTEGER tmp;
+        tmp.QuadPart = readptr;
+        if (!SetFilePointerEx(fd, tmp, &tmp, FILE_BEGIN)) {
+            resolver->logger->info("Failed to seek: {}", GetLastErrorMessage());
+            return IO_ERROR;
+        }
+    }
+
+    if (!ReadFile(fd, data, buf_length, &buf_length, nullptr)) {
+        return IO_ERROR;
+    }
+
+    *length = buf_length;
+    readptr += *length;
+
+    return STATUS_OK;
+}
+
+
+
+AFF4Status FileBackedObject::Write(const char* data, size_t length) {
     // Dont even try to write on files we are not allowed to write on.
     if (!properties.writable) {
         return IO_ERROR;
@@ -344,7 +367,24 @@ std::string FileBackedObject::Read(size_t length) {
     return std::string(result.get(), res);
 }
 
-AFF4Status FileBackedObject::Write(const char* data, int length) {
+AFF4Status FileBackedObject::ReadBuffer(char* data, size_t *length) {
+    if (!properties.writable) {
+        return IO_ERROR;
+    }
+
+    lseek(fd, readptr, SEEK_SET);
+    int res = read(fd, data, *length);
+    if (res >= 0) {
+        readptr += res;
+        *length = res;
+    } else {
+        return IO_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+AFF4Status FileBackedObject::Write(const char* data, size_t length) {
     if (!properties.writable) {
         return IO_ERROR;
     }
@@ -437,7 +477,7 @@ std::string AFF4BuiltInStreams::Read(size_t length) {
     return "";
 }
 
-AFF4Status AFF4BuiltInStreams::Write(const char* data, int length) {
+AFF4Status AFF4BuiltInStreams::Write(const char* data, size_t length) {
     int res = write(fd, data, length);
     if (res >= 0) {
         readptr += res;

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -48,7 +48,8 @@ class FileBackedObject: public AFF4Stream {
     virtual ~FileBackedObject();
 
     std::string Read(size_t length) override;
-    AFF4Status Write(const char* data, int length) override;
+    AFF4Status ReadBuffer(char* data, size_t *length) override;
+    AFF4Status Write(const char* data, size_t length) override;
 
     /**
      * Load the file from a file:/ URN.
@@ -94,7 +95,7 @@ class AFF4BuiltInStreams : public AFF4Stream {
  public:
     explicit AFF4BuiltInStreams(DataStore *resolver): AFF4Stream(resolver) {}
     std::string Read(size_t length) override;
-    AFF4Status Write(const char* data, int length) override;
+    AFF4Status Write(const char* data, size_t length) override;
      AFF4Status LoadFromURN() override;
     AFF4Status Truncate() override;
 

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -446,7 +446,7 @@ AFF4Status AFF4Image::FlushBevy() {
 }
 
 
-AFF4Status AFF4Image::Write(const char* data, int length) {
+AFF4Status AFF4Image::Write(const char* data, size_t length) {
     if (length <= 0) return STATUS_OK;
 
     // Prepare a bevy writer to collect the first bevy.

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -160,7 +160,7 @@ class AFF4Image: public AFF4Stream {
         AFF4Stream* source,
         ProgressContext* progress = nullptr) override;
 
-    AFF4Status Write(const char* data, int length) override;
+    AFF4Status Write(const char* data, size_t length) override;
 
     /**
      * Read data from the current read pointer.

--- a/aff4/aff4_imager_utils.h
+++ b/aff4/aff4_imager_utils.h
@@ -228,7 +228,11 @@ class BasicImager {
                    "where to find the stream. Specifying a relative URN "
                    "implies a stream residing in a loaded volume. E.g.\n"
 
-                   " -e /dev/sda -o /tmp/myfile my_volume.aff4",
+                   " -e /dev/sda -D /tmp/ my_volume.aff4",
+                   false, "", "string"));
+
+        AddArg(new TCLAP::ValueArg<std::string>(
+                   "", "logfile", "Specify a file to store log messages to",
                    false, "", "string"));
 
         AddArg(new TCLAP::ValueArg<std::string>(

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -617,7 +617,7 @@ AFF4Status AFF4Map::GetBackingStream(URN& target) {
 }
 
 
-AFF4Status AFF4Map::Write(const char* data, int length) {
+AFF4Status AFF4Map::Write(const char* data, size_t length) {
     URN target;
     RETURN_IF_ERROR(GetBackingStream(target));
 
@@ -682,7 +682,6 @@ AFF4Status AFF4Map::WriteStream(AFF4Map* source, ProgressContext* progress) {
 
     return result;
 }
-
 
 static AFF4Registrar<AFF4Map> map1(AFF4_MAP_TYPE);
 static AFF4Registrar<AFF4Map> map2(AFF4_LEGACY_MAP_TYPE);

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -72,7 +72,7 @@ class AFF4Map: public AFF4Stream {
     AFF4Status LoadFromURN() override;
 
     std::string Read(size_t length) override;
-    AFF4Status Write(const char* data, int length) override;
+    AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status WriteStream(
         AFF4Stream* source,

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -699,7 +699,7 @@ AFF4Status ZipFileSegment::Truncate() {
     return StringIO::Truncate();
 }
 
-AFF4Status ZipFileSegment::Write(const char* data, int length) {
+AFF4Status ZipFileSegment::Write(const char* data, size_t length) {
     // The segment is mapped from the backing store and the user wants to modify
     // it. We need to make a local copy.
     if (_backing_store_start_offset > 0) {

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -173,7 +173,7 @@ class ZipFileSegment: public StringIO {
     AFF4Status Truncate() override;
 
     std::string Read(size_t length) override;
-    AFF4Status Write(const char* data, int length) override;
+    AFF4Status Write(const char* data, size_t length) override;
 
     aff4_off_t Size() override;
 

--- a/tools/pmem/win_pmem.h
+++ b/tools/pmem/win_pmem.h
@@ -112,7 +112,10 @@ class WinPmemImager: public PmemImager {
    *
    * @return STATUS_OK if successful.
    */
-  virtual AFF4Status ImagePhysicalMemory();
+  AFF4Status ImagePhysicalMemory() override;
+
+  AFF4Status WriteMapObject_(
+      const URN &map_urn, const URN &output_urn) override;
 
   /**
    * Attemptes to unpack and install the driver.


### PR DESCRIPTION
Under Windows VSM reading memory can actually produce an error. We
therefore need to be able to trap the error and mark the page as
unreadable in the AFF4 map properly.