### PR TITLE
Support Unicode.

### DIFF
--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -456,7 +456,7 @@ AFF4Registrar<FileBackedObject> file2(AFF4_FILE_TYPE);
 
 
 AFF4Status AFF4BuiltInStreams::LoadFromURN() {
-    auto type = urn.Parse().domain;
+    auto type = urn.Domain();
 
     // Right now we only support writing to stdout.
     if (type == "stdout") {

--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -55,7 +55,7 @@ AFF4Status ImageStream(DataStore& resolver, const std::vector<URN>& input_urns,
         }
 
         // Create a new image in this volume.
-        URN image_urn = zip->urn.Append(input_urn.Parse().path);
+        URN image_urn = zip->urn.Append(input_urn.Path());
 
         AFF4ScopedPtr<AFF4Image> image = AFF4Image::NewAFF4Image(
                                              &resolver, image_urn, zip->urn);
@@ -377,7 +377,7 @@ AFF4Status BasicImager::process_input() {
                 URN current_dir_urn = URN::NewURNFromFilename(cwd, false);
                 image_urn.Set(volume_urn.Append(current_dir_urn.RelativePath(input_urn)));
             } else {
-                image_urn.Set(volume_urn.Append(input_urn.Parse().path));
+                image_urn.Set(volume_urn.Append(input_urn.Path()));
 
                 // Store the original filename.
                 resolver.Set(image_urn, AFF4_STREAM_ORIGINAL_FILENAME,
@@ -498,8 +498,9 @@ AFF4Status BasicImager::handle_export() {
     for (const URN& export_urn: urns) {
         // Prepend the domain (AFF4 volume) to the export directory to
         // make sure the exported stream is unique.
-        URN output_urn = export_dir_urn.Append(export_urn.Domain()).Append(
-            export_urn.Path());
+        URN output_urn = export_dir_urn.Append(
+            export_urn.Domain()).Append(
+                export_urn.Path());
         resolver.logger->info("Writing to {}", output_urn);
 
         // Hold all the volumes in use while we extract the streams

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -504,7 +504,6 @@ class DataStore {
         }
 
         std::unique_ptr<AFF4Object> obj;
-        const uri_components components = urn.Parse();
 
         // Check if there is a resolver triple for it.
         std::vector<std::shared_ptr<RDFValue>> types;
@@ -530,7 +529,8 @@ class DataStore {
 
         // Try to instantiate the handler based on the URN scheme alone.
         if (!obj) {
-            obj = GetAFF4ClassFactory()->CreateInstance(components.scheme, this, &urn);
+            obj = GetAFF4ClassFactory()->CreateInstance(
+                urn.Scheme(), this, &urn);
             if (obj) {
                 obj->urn = urn;
                 if (obj->LoadFromURN() != STATUS_OK) {

--- a/aff4/lexicon.inc
+++ b/aff4/lexicon.inc
@@ -19,11 +19,16 @@ LEXICON_DEFINE(AFF4_LEGACY_NAMESPACE, "http://afflib.org/2009/aff4#");
  * The default AFF4 prefix for AFF4 objects.
  */
 LEXICON_DEFINE(AFF4_PREFIX, "aff4://");
+LEXICON_DEFINE(FILE_PREFIX, "file://");
 
 // Attributes in this namespace will never be written to persistant
 // storage. They are simply used as a way for storing metadata about an AFF4
 // object internally.
 LEXICON_DEFINE(AFF4_VOLATILE_NAMESPACE, "http://aff4.org/VolatileSchema#");
+
+// We just store the member_name -> URN mapping so we can ensure the
+// right member is opened.
+LEXICON_DEFINE(AFF4_SEGMENT_FOR_URN, "http://aff4.org/VolatileSchema#segment_for_urn");
 
 // Commonly used RDF types.
 LEXICON_DEFINE(URNType, "URN");

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -429,7 +429,12 @@ URN CompressionMethodToURN(AFF4_IMAGE_COMPRESSION_ENUM method) {
 }
 
 
-// Utilities
+// Utilities.
+
+// Convert a member's name into a URN. NOTE: This function is not
+// unicode safe and may mess up the zip segment name if the URN
+// contains unicode chars. Ultimately it does not matter as the member
+// name is just a convenience to the URN.
 std::string member_name_for_urn(const URN member, const URN base_urn,
                                 bool slash_ok) {
     std::string filename = base_urn.RelativePath(member);
@@ -440,10 +445,10 @@ std::string member_name_for_urn(const URN member, const URN base_urn,
         filename = filename.substr(1, filename.size());
     }
 
-    // Now escape any chars which are non printable.
+    // Now escape any chars which are forbidden.
     for (unsigned int i = 0; i < filename.size(); i++) {
         char j = filename[i];
-        if ((!std::isprint(j) || j == '!' || j == '$' ||
+        if ((j == '!' || j == '$' ||
                 j == '\\' || j == ':' || j == '*' || j == '%' ||
                 j == '?' || j == '"' || j == '<' || j == '>' || j == '|') ||
                 (!slash_ok && j == '/')) {
@@ -510,7 +515,6 @@ std::vector<std::string>& split(const std::string& s, char delim,
     return elems;
 }
 
-
 std::vector<std::string> split(const std::string& s, char delim) {
     std::vector<std::string> elems;
     split(s, delim, elems);
@@ -571,8 +575,5 @@ int fnmatch(const char *pattern, const char *string) {
 }
 
 #endif
-
-
-
 
 } // namespace aff4

--- a/aff4/rdf.h
+++ b/aff4/rdf.h
@@ -274,20 +274,12 @@ class URN: public XSDString {
     URN Append(const std::string& component) const;
 
     raptor_term* GetRaptorTerm(raptor_world* world) const;
-    uri_components Parse() const;
 
-    // Convenience methods for Parse()
-    std::string Scheme() const {
-        return Parse().scheme;
-    }
-
-    std::string Path() const {
-        return Parse().path;
-    }
-
-    std::string Domain() const {
-        return Parse().domain;
-    }
+    // Returns the URN's Scheme, Path and Domain parts. NOTE: This is
+    // not a complete URI parser! It only supports AFF4 and FILE urls.
+    std::string Scheme() const;
+    std::string Path() const;
+    std::string Domain() const;
 
     /**
      * returns the path of the URN relative to ourselves.


### PR DESCRIPTION
Remove use of UriParse because it is hard to use with unicode - it
requires use of wchar_t which is a PITA. We just keep using UTF8
throughout.

Add instead a simple URI parser which supports only AFF4, FILE urns.