### PR TITLE
Fix integer overflow in aff4::min()

### DIFF
--- a/README.windows
+++ b/README.windows
@@ -3,7 +3,7 @@ Building for windows.
 
 The following instructions are for building windows binaries, on a
 Linux system. On Ubuntu systems one must install the mingw platform
-first (using apt-get install g++-mingw-w64 mingw-w64).
+first (using apt-get install g++-mingw-w64-i686).
 
 This installs several flavors of compilers. We need the posix version
 so you will need to switch via ubuntu's alternatives version:
@@ -105,8 +105,9 @@ cmake -DCMAKE_TOOLCHAIN_FILE=Toolchain-mingw32.cmake -DCMAKE_INSTALL_PREFIX:PATH
 make install -j4
 cd ..
 
-git clone https://github.com/gabime/spdlog.git
-cd spdlog/
+wget https://github.com/gabime/spdlog/archive/v0.17.0.tar.gz
+tar -xvzf v0.17.0.tar.gz
+cd spdlog-0.17.0/
 cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX . && make install -j4
 cd ..
 

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -726,7 +726,8 @@ std::string AFF4Image::Read(size_t length) {
         return "";
     }
 
-    length = std::min((aff4_off_t)length, aff4::max(0, Size() - readptr));
+    length = std::min((aff4_off_t)length,
+                      std::max((aff4_off_t)0, (aff4_off_t)Size() - readptr));
 
     int initial_chunk_offset = readptr % chunk_size;
     unsigned int initial_chunk_id = readptr / chunk_size;
@@ -757,7 +758,7 @@ std::string AFF4Image::Read(size_t length) {
     }
 
     result.resize(length);
-    readptr = aff4::min(readptr + length, Size());
+    readptr = std::min(readptr + length, (aff4_off_t)Size());
 
     return result;
 }

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -106,24 +106,27 @@ std::string AFF4Map::Read(size_t length) {
         // No range contains the current readptr - just pad it.
         if (map_it == map.end()) {
             result.resize(length);
+            //            readptr += length;
             return result;
         }
 
         Range range = map_it->second;
         aff4_off_t length_to_start_of_range = std::min(
-                (aff4_off_t)length, (aff4_off_t)range.map_offset - readptr);
+            (aff4_off_t)length, (aff4_off_t)(range.map_offset - readptr));
         if (length_to_start_of_range > 0) {
             // Null pad it.
             result.resize(result.size() + length_to_start_of_range);
-            length = aff4::max(length - length_to_start_of_range, 0);
-            readptr = aff4::min(readptr + length_to_start_of_range, Size());
+            length = std::max((aff4_off_t)0,
+                              (aff4_off_t)length - length_to_start_of_range);
+            readptr = std::min((aff4_off_t)Size(),
+                               readptr + length_to_start_of_range);
             continue;
         }
 
         // The readptr is inside a range.
         URN target = targets[range.target_id];
-        size_t length_to_read_in_target = aff4::min(
-                length, range.map_end() - readptr);
+        size_t length_to_read_in_target = std::min(
+            length, (size_t)(range.map_end() - readptr));
 
         aff4_off_t offset_in_target = range.target_offset + (
                                           readptr - range.map_offset);
@@ -137,8 +140,8 @@ std::string AFF4Map::Read(size_t length) {
                                    target.value, urn.value, readptr);
             // Null pad
             result.resize(result.size() + length_to_read_in_target);
-            length = aff4::max(length - length_to_read_in_target, 0);
-            readptr = aff4::min(readptr + length_to_read_in_target, Size());
+            length = std::max((size_t)0, length - length_to_read_in_target);
+            readptr = std::min(Size(), readptr + length_to_read_in_target);
             continue;
         }
 
@@ -154,8 +157,8 @@ std::string AFF4Map::Read(size_t length) {
             };
             result += data;
         }
-        readptr = aff4::min(readptr + length_to_read_in_target, Size());
-        length = aff4::max(length - length_to_read_in_target, 0);
+        readptr = std::min(Size(), readptr + length_to_read_in_target);
+        length = std::max((size_t)0, length - length_to_read_in_target);
     }
 
     return result;

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -106,7 +106,7 @@ std::string AFF4Map::Read(size_t length) {
         // No range contains the current readptr - just pad it.
         if (map_it == map.end()) {
             result.resize(length);
-            //            readptr += length;
+            readptr += length;
             return result;
         }
 

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -539,14 +539,6 @@ void aff4_init() {
 }
 
 
-aff4_off_t min(size_t x, aff4_off_t y) {
-    return std::min((aff4_off_t)x, y);
-}
-
-aff4_off_t max(size_t x, aff4_off_t y) {
-    return std::max((aff4_off_t)x, y);
-}
-
 std::shared_ptr<spdlog::logger> get_logger() {
     auto logger = spdlog::get("aff4");
 

--- a/aff4/libaff4.h
+++ b/aff4/libaff4.h
@@ -66,9 +66,6 @@ extern "C" {
 }
 
 
-aff4_off_t min(size_t x, aff4_off_t y);
-aff4_off_t max(size_t x, aff4_off_t y);
-
 std::string aff4_sprintf(std::string fmt, ...);
 
 } // namespace aff4

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -915,6 +915,25 @@ AFF4Status ZipInfo::WriteFileHeader(AFF4Stream& output) {
     struct ZipFileHeader header;
     struct Zip64FileHeaderExtensibleField zip64header;
 
+    if (file_size < 0xFFFFFFFF) {
+        header.crc32_cs = crc32_cs;
+        header.compress_size = compress_size;
+        header.file_size = file_size;
+        header.flags = 0;
+        header.file_name_length = filename.length();
+        header.compression_method = compression_method;
+        header.lastmodtime = lastmodtime;
+        header.lastmoddate = lastmoddate;
+        header.extra_field_len = 0;
+        if (output.properties.seekable) {
+            RETURN_IF_ERROR(output.Seek(file_header_offset, SEEK_SET));
+        }
+        RETURN_IF_ERROR(output.Write(reinterpret_cast<char*>(&header), sizeof(header)));
+        RETURN_IF_ERROR(output.Write(filename));
+
+        return STATUS_OK;
+    }
+
     header.crc32_cs = crc32_cs;
     header.compress_size = 0xFFFFFFFF;
     header.file_size = 0xFFFFFFFF;
@@ -942,6 +961,24 @@ AFF4Status ZipInfo::WriteFileHeader(AFF4Stream& output) {
 AFF4Status ZipInfo::WriteCDFileHeader(AFF4Stream& output) {
     struct CDFileHeader header;
     struct Zip64FileHeaderExtensibleField zip64header;
+
+    if (file_size < 0xFFFFFFFF && local_header_offset < 0xFFFFFFFF) {
+        header.compression_method = compression_method;
+        header.crc32_cs = crc32_cs;
+        header.file_name_length = filename.length();
+        header.dostime = lastmodtime;
+        header.dosdate = lastmoddate;
+        header.file_size = file_size;
+        header.compress_size = compress_size;
+        header.relative_offset_local_header = local_header_offset;
+        header.extra_field_len = 0;
+
+        RETURN_IF_ERROR(output.Write(reinterpret_cast<char*>(&header),
+                                     sizeof(header)));
+        RETURN_IF_ERROR(output.Write(filename));
+
+        return STATUS_OK;
+    }
 
     header.compression_method = compression_method;
     header.crc32_cs = crc32_cs;
@@ -1096,6 +1133,7 @@ AFF4Status ZipFile::StreamAddMember(URN member_urn, AFF4Stream& stream,
                                      reinterpret_cast<Bytef*>(const_cast<char*>(buffer.data())),
                                      buffer.size());
 
+            RETURN_IF_ERROR(backing_store->Seek(0, SEEK_END))
             RETURN_IF_ERROR(backing_store->Write(buffer.data(), buffer.size()));
 
             // Report progress.

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -1053,6 +1053,11 @@ AFF4Status ZipFile::StreamAddMember(URN member_urn, AFF4Stream& stream,
             // Give the compressor more room.
             strm.next_out = reinterpret_cast<Bytef*>(c_buffer.get());
             strm.avail_out = AFF4_BUFF_SIZE;
+
+            // Report progress.
+            if (!progress->Report(stream.Tell())) {
+                return ABORTED;
+            }
         }
 
         // Give the compressor more room.
@@ -1092,6 +1097,11 @@ AFF4Status ZipFile::StreamAddMember(URN member_urn, AFF4Stream& stream,
                                      buffer.size());
 
             RETURN_IF_ERROR(backing_store->Write(buffer.data(), buffer.size()));
+
+            // Report progress.
+            if (!progress->Report(stream.Tell())) {
+                return ABORTED;
+            }
         }
     }
 

--- a/m4/libtool.m4
+++ b/m4/libtool.m4
@@ -728,7 +728,6 @@ _LT_CONFIG_SAVE_COMMANDS([
     cat <<_LT_EOF >> "$cfgfile"
 #! $SHELL
 # Generated automatically by $as_me ($PACKAGE) $VERSION
-# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
 # NOTE: Changes made to this file will be lost: look at ltmain.sh.
 
 # Provide generalized library-building support services.
@@ -2887,6 +2886,18 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   dynamic_linker='GNU/Linux ld.so'
   ;;
 
+netbsdelf*-gnu)
+  version_type=linux
+  need_lib_prefix=no
+  need_version=no
+  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+  soname_spec='${libname}${release}${shared_ext}$major'
+  shlibpath_var=LD_LIBRARY_PATH
+  shlibpath_overrides_runpath=no
+  hardcode_into_libs=yes
+  dynamic_linker='NetBSD ld.elf_so'
+  ;;
+
 netbsd*)
   version_type=sunos
   need_lib_prefix=no
@@ -3546,7 +3557,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   lt_cv_deplibs_check_method=pass_all
   ;;
 
-netbsd*)
+netbsd* | netbsdelf*-gnu)
   if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
     lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
   else
@@ -4424,7 +4435,7 @@ m4_if([$1], [CXX], [
 	    ;;
 	esac
 	;;
-      netbsd*)
+      netbsd* | netbsdelf*-gnu)
 	;;
       *qnx* | *nto*)
         # QNX uses GNU C++, but need to define -shared option too, otherwise
@@ -4936,6 +4947,9 @@ m4_if([$1], [CXX], [
       ;;
     esac
     ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
+    ;;
   *)
     _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
     ;;
@@ -4997,6 +5011,9 @@ dnl Note also adjust exclude_expsyms for C++ above.
     ;;
   openbsd* | bitrig*)
     with_gnu_ld=no
+    ;;
+  linux* | k*bsd*-gnu | gnu*)
+    _LT_TAGVAR(link_all_deplibs, $1)=no
     ;;
   esac
 
@@ -5252,7 +5269,7 @@ _LT_EOF
       fi
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
 	wlarc=
@@ -5773,6 +5790,7 @@ _LT_EOF
 	if test yes = "$lt_cv_irix_exported_symbol"; then
           _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
 	fi
+	_LT_TAGVAR(link_all_deplibs, $1)=no
       else
 	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -o $lib'
 	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry $output_objdir/so_locations -exports_file $export_symbols -o $lib'
@@ -5794,7 +5812,7 @@ _LT_EOF
       esac
       ;;
 
-    netbsd*)
+    netbsd* | netbsdelf*-gnu)
       if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
 	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
       else
@@ -6420,7 +6438,7 @@ if test yes != "$_lt_caught_CXX_error"; then
       # Commands to make compiler produce verbose output that lists
       # what "hidden" libraries, object files and flags are used when
       # linking a shared library.
-      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP " \-L"'
 
     else
       GXX=no
@@ -6795,7 +6813,7 @@ if test yes != "$_lt_caught_CXX_error"; then
             # explicitly linking system object files so we need to strip them
             # from the output so that they don't get included in the library
             # dependencies.
-            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP " \-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
             ;;
           *)
             if test yes = "$GXX"; then
@@ -6860,7 +6878,7 @@ if test yes != "$_lt_caught_CXX_error"; then
 	    # explicitly linking system object files so we need to strip them
 	    # from the output so that they don't get included in the library
 	    # dependencies.
-	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
+	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP " \-L"`; list= ; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
 	    ;;
           *)
 	    if test yes = "$GXX"; then
@@ -7199,7 +7217,7 @@ if test yes != "$_lt_caught_CXX_error"; then
 	      # Commands to make compiler produce verbose output that lists
 	      # what "hidden" libraries, object files and flags are used when
 	      # linking a shared library.
-	      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+	      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP " \-L"'
 
 	    else
 	      # FIXME: insert proper C++ library support
@@ -7283,7 +7301,7 @@ if test yes != "$_lt_caught_CXX_error"; then
 	        # Commands to make compiler produce verbose output that lists
 	        # what "hidden" libraries, object files and flags are used when
 	        # linking a shared library.
-	        output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+	        output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP " \-L"'
 	      else
 	        # g++ 2.7 appears to require '-G' NOT '-shared' on this
 	        # platform.
@@ -7294,7 +7312,7 @@ if test yes != "$_lt_caught_CXX_error"; then
 	        # Commands to make compiler produce verbose output that lists
 	        # what "hidden" libraries, object files and flags are used when
 	        # linking a shared library.
-	        output_verbose_link_cmd='$CC -G $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
+	        output_verbose_link_cmd='$CC -G $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP " \-L"'
 	      fi
 
 	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-R $wl$libdir'

--- a/tools/pmem/win_pmem.cc
+++ b/tools/pmem/win_pmem.cc
@@ -418,7 +418,8 @@ AFF4Status WinPmemImager::WriteMapObject_(
     aff4_off_t unreadable_offset = 0;
 
     for (aff4_off_t j=range.start; j<range.start + range.length; j += BUFF_SIZE) {
-        size_t to_read = min(range.start + range.length - j, BUFF_SIZE);
+        size_t to_read = std::min((aff4_off_t)(BUFF_SIZE),
+                                  (aff4_off_t)(range.start + range.length - j));
         size_t buffer_len = to_read;
         device_stream->Seek(j, SEEK_SET);
 


### PR DESCRIPTION
The aff4::min() function was introduced as a helper substitute to std::min() which takes size_t and aff4_off_t. Unfortunately this is problematic because C++ silently rounds down aff4_off_t (64bit) into size_t (32 bit).

This rounding caused issue #40 and #39 

This change removes the aff4::min function and just explicitely casts into std::min.