### PR TITLE
Disable AFF4 volume when extension is not .aff4.

### DIFF
--- a/aff4/aff4_utils.h
+++ b/aff4/aff4_utils.h
@@ -54,6 +54,17 @@ std::shared_ptr<spdlog::logger> get_logger();
 // A portable version of fnmatch.
 int fnmatch(const char *pattern, const char *string);
 
+inline bool hasEnding(std::string const &fullString, std::string const &ending) {
+    if (fullString.length() >= ending.length()) {
+        return (0 == fullString.compare(
+                    fullString.length() - ending.length(),
+                    ending.length(), ending));
+    } else {
+         return false;
+    }
+}
+
+
 } // namespace aff4
 
 #endif  // SRC_AFF4_UTILS_H_

--- a/tools/pmem/pmem.h
+++ b/tools/pmem/pmem.h
@@ -41,6 +41,8 @@ class PmemImager: public BasicImager {
     virtual AFF4Status handle_pagefiles();
     virtual AFF4Status handle_compression();
 
+    virtual AFF4Status process_input();
+
     /**
      * Actually create the image of physical memory.
      *


### PR DESCRIPTION
When outputting to raw or ELF it is expected that the output be a flat
file and not an AFF4 volume. Unless the filename ends with .aff4, this
will now be a flat file.

When writing to a flat file we can not append any other streams. This
is obviously less useful.