### PR TITLE
Improve handling of VSM memory when dumping to raw file formats

### DIFF
--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -200,7 +200,7 @@ std::string FileBackedObject::Read(size_t length) {
     }
 
     if (!ReadFile(fd, result.get(), buffer_size, &buffer_size, nullptr)) {
-        resolver->logger->error("Reading failed at {:x}: {}", readptr,
+        resolver->logger->warn("Reading failed at {:x}: {}", readptr,
                                 GetLastErrorMessage());
 
         return "";

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -169,7 +169,7 @@ std::string AFF4Map::Read(size_t length) {
 
                 size_t reread_total = 0;
                 while (reread_total < length_to_read_in_target) {
-                    size_t reread_want = std::min((size_t)(length_to_read_in_target - reread_total), (size_t)4096); // should be PAGE_SIZE
+                    size_t reread_want = std::min((size_t)(length_to_read_in_target - reread_total), max_reread_size);
                     int reread_actual = target_stream->ReadIntoBuffer((void *)buffer, reread_want);
                     if (reread_actual < reread_want) {
                         resolver->logger->info(

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -152,11 +152,39 @@ std::string AFF4Map::Read(size_t length) {
         {
             std::string data = target_stream->Read(length_to_read_in_target);
             if (data.size() < length_to_read_in_target) {
-                resolver->logger->error(
-                    "Map target {} can not produced required {} bytes. Null padding "
-                    "{} bytes!", target_stream->urn.SerializeToString(),
-                    length_to_read_in_target, length_to_read_in_target - data.size());
+                // Failed to read some portion of memory. On Windows platforms, this is usually
+                // due to Virtual Secure Mode (VSM) memory. Re-read memory in smaller units,
+                // while leaving the unreadable regions null-padded.
+                resolver->logger->info(
+                    "Map target {} can not produced required {} bytes at offset 0x{:x}. Got {} bytes. Will re-read one page at a time.",
+                    target_stream->urn.SerializeToString(),
+                    length_to_read_in_target, offset_in_target, data.size());
+
+                // Reset target_strem back to original position, and then re-read one page at a time.
+                target_stream->Seek(offset_in_target, SEEK_SET);
+
+                // Grow the data buffer to the expected size, filled to the end with null bytes.
                 data.resize(length_to_read_in_target, 0);
+                const char* buffer = data.data();
+
+                size_t reread_total = 0;
+                while (reread_total < length_to_read_in_target) {
+                    size_t reread_want = std::min((size_t)(length_to_read_in_target - reread_total), (size_t)4096); // should be PAGE_SIZE
+                    int reread_actual = target_stream->ReadIntoBuffer((void *)buffer, reread_want);
+                    if (reread_actual < reread_want) {
+                        resolver->logger->info(
+                            "Map target {}: Read error starting at offset 0x{:x} of {} bytes. Expected {} bytes. Null padding.",
+                            target_stream->urn.SerializeToString(),
+                            offset_in_target+reread_total,
+                            reread_actual, reread_want);
+                    }
+                    reread_total += reread_want;
+                    // Advance the pointer in the buffer.
+                    buffer += reread_want;
+
+                    // ensure that we seek to the correct position in target_stream
+                    target_stream->Seek(offset_in_target+reread_total, SEEK_SET);
+                }
             };
             result += data;
         }

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -64,6 +64,10 @@ class AFF4Map: public AFF4Stream {
     std::map<std::string, int> target_idx_map;
     std::map<aff4_off_t, Range> map;
 
+    // Specifies the fallback read-size to use when Read encounters
+    // an unreadable region.
+    size_t max_reread_size = 4096;
+
     explicit AFF4Map(DataStore* resolver): AFF4Stream(resolver) {}
 
     static AFF4ScopedPtr<AFF4Map> NewAFF4Map(


### PR DESCRIPTION
Instead of the approach that @scudette had originally suggested (copy-pasta of WinPmemImager::WriteMapObject_, then tweaking), I chose to modify AFF4Map::Read so that it would attempt to read smaller chunks of memory if it encountered a region that appeared to be unreadable. This has the added advantage of being cross-platform, so if similar issues were to present on non-windows platforms, they would be handled similarly. 

I took this approach with the hope that it would eliminate the need for WinPmemImager::WriteMapObject_, however it appears that in no way traverses AFF4Map::Read.

Regardless, I still think that this is a simpler approach. I really didn't think it wise to add yet another place where memory regions are iterated, and then operated upon. 