### PR TITLE
Docker build changes - prevent stripping of driver.

### DIFF
--- a/README.docker
+++ b/README.docker
@@ -17,6 +17,7 @@ Building:
   - This builds the docker image, which contains all of the dependencies.
 - To run configure step: "docker-compose.exe run --rm builder-win32 configure"
   - Configure script is defined in docker/entrypoint.sh
+  - Alternatively, if you'd like to create a debug build: "docker-compose.exe run --rm builder-win32 configure-debug"
 - To build: "docker-compose.exe run --rm builder-win32 build"
   - stripped binaries can be found in build/win32
   - Un-stripped binaries (with debugging symbols intact) can be found in the source tree (ex: tools/pmem/winpmem.exe)

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,24 @@ AC_ARG_WITH([yaml], [AS_HELP_STRING([--with-yaml], [Enable YAML support (default
 AC_ARG_ENABLE([static-binaries],
    AS_HELP_STRING([--enable-static-binaries], [Build completely static binaries]))
 
+has_compiler_strip_flag=no
+AX_CHECK_COMPILE_FLAG([-s],
+    [has_compiler_strip_flag=yes])
+
+AC_ARG_ENABLE([strip],
+   AS_HELP_STRING([--disable-strip], [Disable the stripping of symbols from binaries]))
+test no = "$enable_strip" || enable_strip=yes
+  
+if test "x$enable_strip" = "xyes"; then
+  if test "x$has_compiler_strip_flag" = "xyes"; then
+    CXXFLAGS="$CXXFLAGS -s"
+  fi
+else
+  # Disable strip binary
+  AC_SUBST(STRIP,/bin/true)
+fi
+
+
 # Check for optional libraries
 AS_IF([test "x$WITH_YAML" = "xyes"],
   [PKG_CHECK_MODULES([YAML_CPP], [yaml-cpp],

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 
+export EXTRA_CXXFLAGS=
+export EXTRA_LDFLAGS=
+export EXTRA_CONFIG_FLAGS=
+
 function do_configure() {
+    ./autogen.sh
     ./configure --prefix="${AFF4_BUILD_OUTPUT_PATH}" --disable-shared --enable-static --enable-static-binaries \
-        LDFLAGS="${LDFLAGS}" \
-        CXXFLAGS="${CXXFLAGS} -g3 -static" \
+        LDFLAGS="${LDFLAGS} ${EXTRA_LDFLAGS}" \
+        CXXFLAGS="${CXXFLAGS} ${EXTRA_CXXFLAGS} -static" \
+        ${EXTRA_CONFIG_FLAGS} \
         ${AUTOCONF_HOSTFLAG}
+    make clean
 }
 
 function do_build() {
-    make -j4 install-strip
+    make -j4 install
 }
 
 function do_help() {
-    echo Valid commands are 'configure', 'build', and 'help'.
+    echo Valid commands are 'configure', 'configure-debug', 'build', and 'help'.
     echo If no command is specified, 'configure' and then 'build' will be run.
     echo Any other commands will be executed by the shell.
     exit 0
@@ -30,6 +37,15 @@ if [ "$#" -eq 0 ]; then
     exit 0
 elif [ "$#" -eq 1 ]; then
     if [ "$1" == "configure" ]; then
+        # Disable debugging symbols completely
+        export EXTRA_CXXFLAGS="-g0 -O2"
+        export EXTRA_LDFLAGS="-g0"
+        do_configure
+        exit 0
+    elif [ "$1" == "configure-debug" ]; then
+        export EXTRA_CXXFLAGS="-ggdb3 -O0"
+        export EXTRA_LDFLAGS="-ggdb3"
+        export EXTRA_CONFIG_FLAGS="--disable-strip"
         do_configure
         exit 0
     elif [ "$1" == "build" ]; then

--- a/tools/pmem/Makefile.am
+++ b/tools/pmem/Makefile.am
@@ -35,7 +35,7 @@ if WINDOWS
 bin_PROGRAMS = winpmem
 
 winpmem_LDFLAGS = $(STATIC_LINKERLDFLAGS)
-winpmem_CXXFLAGS = -std=c++11 -g -Wall -O0
+winpmem_CXXFLAGS = -std=c++11 -Wall
 winpmem_SOURCES = pmem_imager.cc win_pmem.cc
 winpmem_LDADD = -lrpcrt4 -lshlwapi $(top_srcdir)/aff4/libaff4.la -lyaml-cpp
 
@@ -48,7 +48,7 @@ endif
 if LINUX
 bin_PROGRAMS = linpmem
 linpmem_LDFLAGS = $(STATIC_LINKERLDFLAGS)
-linpmem_CXXFLAGS = -std=c++11 -g -Wall -O0
+linpmem_CXXFLAGS = -std=c++11 -Wall
 linpmem_SOURCES = pmem_imager.cc linux_pmem.cc
 linpmem_LDADD = $(top_srcdir)/aff4/libaff4.la
 all-local: linpmem
@@ -58,7 +58,7 @@ if OSX
 bin_PROGRAMS = osxpmem
 
 osxpmem_LDFLAGS = $(STATIC_LINKERLDFLAGS)
-osxpmem_CXXFLAGS = -std=c++11 -g -Wall -O0
+osxpmem_CXXFLAGS = -std=c++11 -Wall
 osxpmem_SOURCES = pmem_imager.cc osxpmem.cc
 osxpmem_LDADD = $(top_srcdir)/aff4/libaff4.la -lyaml-cpp
 


### PR DESCRIPTION
- Add configure option "--disable-strip" that will try to prevent
stripping binaries during compile and installation.
- When --disable-strip is not specified, compiler-flag "-s" is added to
CXXFLAGS, which will cause outputs to be stripped.
- Added entrypoint "configure-debug" which will enable debug builds of
c-aff4. Debugging symbols are added with "-ggdb3", stripping is
disabled, optimizations are disabled.
- Modified entrypoint "configure": optimization is now "-O2", and
debugging symbols are explicitly disabled with "-g0".
- Modified ntrypoint "build": use "install" target instead of
"install-strip". Fixes #51