### PR TITLE
std::min compile fixes

### DIFF
--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -758,7 +758,7 @@ std::string AFF4Image::Read(size_t length) {
     }
 
     result.resize(length);
-    readptr = std::min(readptr + length, (aff4_off_t)Size());
+    readptr = std::min((aff4_off_t)(readptr + length), Size());
 
     return result;
 }

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -144,7 +144,7 @@ std::string AFF4Map::Read(size_t length) {
             // Null pad
             result.resize(result.size() + length_to_read_in_target);
             length = std::max((size_t)0, length - length_to_read_in_target);
-            readptr = std::min(Size(), readptr + length_to_read_in_target);
+            readptr = std::min(Size(), (aff4_off_t)(readptr + length_to_read_in_target));
             continue;
         }
 
@@ -188,7 +188,7 @@ std::string AFF4Map::Read(size_t length) {
             };
             result += data;
         }
-        readptr = std::min(Size(), readptr + length_to_read_in_target);
+        readptr = std::min(Size(), (aff4_off_t)(readptr + length_to_read_in_target));
         length = std::max((size_t)0, length - length_to_read_in_target);
     }
 


### PR DESCRIPTION
Some compilers (such as latest clang on macOS) are a bit more strict and give errors when trying to compare different types with std::min