### PR TITLE
Remove dependency on libpcre++

### DIFF
--- a/aff4/config.h.in
+++ b/aff4/config.h.in
@@ -24,9 +24,6 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `pcre++' library (-lpcre++). */
-#undef HAVE_LIBPCRE__
-
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #undef HAVE_LIBPTHREAD
 

--- a/aff4/rdf.cc
+++ b/aff4/rdf.cc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations under the License.
 #include "aff4/lexicon.h"
 #include "aff4/rdf.h"
 #include <limits.h>
-#include <pcre++.h>
+#include <regex>
 #include <stdlib.h>
 #include <unistd.h>
 #include <cerrno>
@@ -259,9 +259,9 @@ static std::string abspath(std::string path) {
 std::string URN::ToFilename() const {
     // Alas Microsoft's implementation is also incomplete. Here we check for some
     // edge cases and manually hack around them.
-    pcrepp::Pcre volume_regex("^file://./([a-zA-Z]):$");  // file://./c: -> \\.\c:
-    if (volume_regex.search(value)) {
-        return volume_regex.replace(value, "\\\\.\\$1:");
+    std::regex volume_regex("^file://./([a-zA-Z]):$");  // file://./c: -> \\.\c:
+    if (std::regex_match(value, volume_regex)) {
+        return std::regex_replace(value, volume_regex, "\\\\.\\$1:");
     }
 
     const int bytesNeeded = std::max(value.size() + 1, (size_t)MAX_PATH);

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -23,7 +23,6 @@
  */
 #include "aff4/config.h"
 
-#include <pcre++.h>
 #include <sstream>
 #include <iomanip>
 #include "aff4/zip.h"

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,6 @@ fi
 PKG_CHECK_MODULES([RAPTOR2], [raptor2], [], [AC_MSG_ERROR([raptor RDF library (libraptor2-dev) not found])])
 
 PKG_CHECK_MODULES([ZLIB], [zlib], [], [AC_MSG_ERROR([zlib library (zlib1g-dev) not found])])
-AC_CHECK_LIB([pcre++], [main], [], [AC_MSG_ERROR([pcre++ library (libpcre++-dev) not found])])
 AC_CHECK_LIB([snappy], [main], [], [AC_MSG_ERROR([Google Snappy Compression library (libsnappy-dev) not found])])
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([pthread library not found])])
 


### PR DESCRIPTION
C++ has had support for simple regex matching since C++11.  This PR removes the dependencies on both libpcre and libpcre++ by using the standard library implementation.