### PR TITLE
Remove null terminator from zip volume URN string

### DIFF
--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -181,6 +181,12 @@ AFF4Status ZipFile::parse_cd() {
         resolver->logger->info("Loaded AFF4 volume URN {} from zip file.",
                                urn_string);
 
+        // Sometimes the comment string includes the null terminator.  We need to
+        // handle this case.
+        if (urn_string.back() == '\x00') {
+            urn_string.pop_back();
+        }
+
         // There is a catch 22 here - before we parse the ZipFile we dont know the
         // Volume's URN, but we need to know the URN so the AFF4FactoryOpen() can
         // open it. Therefore we start with a random URN and then create a new


### PR DESCRIPTION
Some AFF4 implementations seem to include a null terminator in the URN string in the zip comment (the official AFF4 sample images do this).  We need to remove this terminator if it exists or there will be problems with string matching.