### PR TITLE
c interface open call should only open image from current container

### DIFF
--- a/aff4/rdf.h
+++ b/aff4/rdf.h
@@ -302,6 +302,10 @@ class URN: public XSDString {
         value = data;
         return STATUS_OK;
     }
+
+    bool operator<(const URN& other) const noexcept {
+        return value < other.value;
+    }
 };
 
 } // namespace aff4


### PR DESCRIPTION
This patch fixes the logic of opening images using the C API.  One would expect that a handle to the first image in the file that was attempted to be opened would be returned, but this wasn't always the case if you had multiple images opened.

This fix guarantees that a handle to an image will be returned only if that image is stored in the file path used in the open call. 