### PR TITLE
Fix divide by zero error occurring in DefaultProgress::Report, use monotonic clock

### DIFF
--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -24,6 +24,7 @@ specific language governing permissions and limitations under the License.
 #include <memory>
 #include <fstream>
 #include <cstdio>
+#include <chrono>
 #include "aff4/aff4_base.h"
 #include "aff4/data_store.h"
 #include "aff4/aff4_utils.h"
@@ -62,7 +63,6 @@ struct AFF4VolumeProperties {
 class ProgressContext {
   public:
     // Maintained by the callback.
-    uint64_t last_time = 0;
     aff4_off_t last_offset = 0;
 
     // The following are set in advance by users in order to get accurate progress
@@ -101,8 +101,14 @@ extern ProgressContext empty_progress;
 // Some default progress functions that come out of the box.
 class DefaultProgress: public ProgressContext {
  public:
-    explicit DefaultProgress(DataStore *resolver): ProgressContext(resolver) {}
+    explicit DefaultProgress(DataStore *resolver): ProgressContext(resolver) {
+        last_time = std::chrono::steady_clock::now();
+    }
     virtual bool Report(aff4_off_t readptr);
+
+ protected:
+    // Managed internally by Report
+    std::chrono::steady_clock::time_point last_time;
 };
 
 class AFF4Stream: public AFF4Object {

--- a/aff4/aff4_utils.h
+++ b/aff4/aff4_utils.h
@@ -18,7 +18,6 @@ specific language governing permissions and limitations under the License.
 
 #include "aff4/config.h"
 
-#include <sys/time.h>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -30,12 +29,6 @@ namespace aff4 {
 #define UNUSED(x) (void)x
 
 std::string aff4_sprintf(std::string fmt, ...);
-
-inline uint64_t time_from_epoch() {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return ((uint64_t) tv.tv_sec * 1000000) + tv.tv_usec;
-}
 
 std::string GetLastErrorMessage();
 

--- a/aff4/aff4_utils.h
+++ b/aff4/aff4_utils.h
@@ -34,7 +34,7 @@ std::string aff4_sprintf(std::string fmt, ...);
 inline uint64_t time_from_epoch() {
     struct timeval tv;
     gettimeofday(&tv, nullptr);
-    return tv.tv_sec * 1000000 + tv.tv_usec;
+    return ((uint64_t) tv.tv_sec * 1000000) + tv.tv_usec;
 }
 
 std::string GetLastErrorMessage();


### PR DESCRIPTION
I found that, while dumping memory, occasionally winpmem would exit with a divide by zero exception. I was able to track this down to DefaultProgress::Report and time_from_epoch. 
time_from_epoch is supposed to return the number of microseconds since epoch. Unfortunately, since it was not properly casting tv.tv_sec prior to doing some math, the value returned by time_from_epoch could look like 0xffffffff800bb69c. 
This would somehow lead to a divide by zero exception within DefaultProgress::Report.  time_from_epoch was effectively limited to 32 bits, of which up to 4294967295 microseconds (~4294 seconds) could be tracked. As a result, if you were unlucky enough to be dumping when time_from_epoch rolled over (0xffffffffffffffff -> 0x0) (once every 4294 seconds), DefaultProgress::Report would throw a divide by zero exception. 

I am able to reproduce this issue by setting my system clock to Nov 13, 2018 11:17:55 UTC-06:00, and then running winpmem 3.1.rc9. When it hits 11:18:02, winpmem crashes with a divide by zero exception (windows error code 0xc0000094). For example:
```
C:\Users\mike\winpmem>date 11-13-2018 && time 11:17:55 && winpmem_3.1.rc9.exe -d -d --format raw --volume_format raw --output - > NUL
2018-11-13 11:17:55 I This is The WinPmem memory imager. version 3.1rc9
2018-11-13 11:17:55 I Extracting WinPmem drivers from binary.
2018-11-13 11:17:55 I Loaded AFF4 volume URN aff4://55297698-31c9-42c3-bb80-48e42c601ffe from zip file.
2018-11-13 11:17:55 I Global offset: 25d95a
2018-11-13 11:17:55 I Openning driver AFF4 volume: aff4://55297698-31c9-42c3-bb80-48e42c601ffe
2018-11-13 11:17:55 I Extracted aff4://55297698-31c9-42c3-bb80-48e42c601ffe/att_winpmem_64.sys to file:///C:/Users/mike/AppData/Local/Temp/pmeC70E.tmp
2018-11-13 11:17:55 I Driver Unloaded.
2018-11-13 11:17:55 I Loaded Driver C:\Users\mike\AppData\Local\Temp\pmeC70E.tmp
2018-11-13 11:17:55 I Setting acquisition mode 2
2018-11-13 11:17:55 I CR3: 0x00001AA000
 4 memory ranges:
Start 0x00001000 - Length 0x0009E000
Start 0x00100000 - Length 0x00002000
Start 0x00103000 - Length 0xBFED7000
Start 0x100000000 - Length 0x340000000

2018-11-13 11:17:55 I Will write in raw format.
2018-11-13 11:17:55 I Setting acquisition mode 2
2018-11-13 11:17:55 I Dumping Range 0 (Starts at 0x001000, length 0x09e000
2018-11-13 11:17:55 I Dumping Range 1 (Starts at 0x100000, length 0x002000
2018-11-13 11:17:55 I Dumping Range 2 (Starts at 0x103000, length 0xbfed7000
2018-11-13 11:17:55 I Dumping Range 3 (Starts at 0x100000000, length 0x340000000
2018-11-13 11:17:55 I Destination volume will be a flat file builtin://stdout.
2018-11-13 11:17:55 I  Reading 8000 0 MiB / 16383 (0 MiB/s)
2018-11-13 11:17:55 I  Reading 2420000 36 MiB / 16383 (144 MiB/s)
2018-11-13 11:17:55 I  Reading 51d8000 81 MiB / 16383 (171 MiB/s)
2018-11-13 11:17:56 I  Reading 86d8000 134 MiB / 16383 (210 MiB/s)
2018-11-13 11:17:56 I  Reading ccb8000 204 MiB / 16383 (262 MiB/s)
2018-11-13 11:17:56 I  Reading 10270000 258 MiB / 16383 (202 MiB/s)
2018-11-13 11:17:56 I  Reading 13e08000 318 MiB / 16383 (236 MiB/s)
2018-11-13 11:17:57 I  Reading 18120000 385 MiB / 16383 (267 MiB/s)
2018-11-13 11:17:57 I  Reading 1c458000 452 MiB / 16383 (252 MiB/s)
2018-11-13 11:17:57 I  Reading 1f650000 502 MiB / 16383 (199 MiB/s)
2018-11-13 11:17:57 I  Reading 22c58000 556 MiB / 16383 (215 MiB/s)
2018-11-13 11:17:58 I  Reading 25ef8000 606 MiB / 16383 (198 MiB/s)
2018-11-13 11:17:58 I  Reading 299b8000 665 MiB / 16383 (234 MiB/s)
2018-11-13 11:17:58 I  Reading 2d738000 727 MiB / 16383 (245 MiB/s)
2018-11-13 11:17:58 I  Reading 31b20000 795 MiB / 16383 (255 MiB/s)
2018-11-13 11:17:59 I  Reading 35498000 852 MiB / 16383 (225 MiB/s)
2018-11-13 11:17:59 I  Reading 39118000 913 MiB / 16383 (241 MiB/s)
2018-11-13 11:17:59 I  Reading 3ca78000 970 MiB / 16383 (215 MiB/s)
2018-11-13 11:17:59 I  Reading 40390000 1027 MiB / 16383 (214 MiB/s)
2018-11-13 11:18:00 I  Reading 44178000 1089 MiB / 16383 (232 MiB/s)
2018-11-13 11:18:00 I  Reading 486b0000 1158 MiB / 16383 (260 MiB/s)
2018-11-13 11:18:00 I  Reading 4c9c8000 1225 MiB / 16383 (251 MiB/s)
2018-11-13 11:18:00 I  Reading 50d38000 1293 MiB / 16383 (268 MiB/s)
2018-11-13 11:18:01 I  Reading 552c8000 1362 MiB / 16383 (261 MiB/s)
2018-11-13 11:18:01 I  Reading 5a190000 1441 MiB / 16383 (296 MiB/s)
2018-11-13 11:18:01 I  Reading 5dbb8000 1499 MiB / 16383 (227 MiB/s)
2018-11-13 11:18:01 I  Reading 61c08000 1564 MiB / 16383 (256 MiB/s)
2018-11-13 11:18:02 I  Reading 658a8000 1624 MiB / 16383 (242 MiB/s)
2018-11-13 11:18:02 I  Reading 692a8000 1682 MiB / 16383 (229 MiB/s)

C:\Users\mike\winpmem>
```

- The first commit 493bb3440670ad79844777df2434b6874b63e513 fixes that above issue.

- The second commit, 55584d4e26cb1ece20580a24ebd4bcf514f243b2, ultimately does away with the above fix and just uses the c++11 std::chrono::steady_clock monotonic clock (a clock that always increases, and is unaffected by system clock changes). At the end of the day, we just want to know how much time has elapsed between reports; what that exact times those reports occur do not matter.

