### PR TITLE
Add logging control to C API

### DIFF
--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -629,6 +629,10 @@ class MemoryDataStore: public DataStore {
     std::unordered_map<std::string, AFF4_Attributes> store;
 
   public:
+    MemoryDataStore() = default;
+
+    MemoryDataStore(DataStoreOptions options): DataStore(options) {}
+
     virtual ~MemoryDataStore();
 
     /**

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -105,13 +105,8 @@ spdlog::level::level_enum enum_for_level(unsigned int level) {
         return spdlog::level::info;
     case 3:
         return spdlog::level::warn;
-    case 4:
-        return spdlog::level::err;
-    case 5:
-        return spdlog::level::critical;
-    case 6:
     default:
-        return spdlog::level::off;
+        return spdlog::level::err;
     }
 }
 

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -93,15 +93,25 @@ Holder& get_holder() {
     return the_holder;
 }
 
-const spdlog::level::level_enum LEVEL_TO_ENUM[] = {
-    spdlog::level::trace,
-    spdlog::level::debug,
-    spdlog::level::info,
-    spdlog::level::warn,
-    spdlog::level::err,
-    spdlog::level::critical,
-    spdlog::level::off
-};
+spdlog::level::level_enum enum_for_level(unsigned int level) {
+    switch (level) {
+    case 0:
+        return spdlog::level::trace;
+    case 1:
+        return spdlog::level::debug;
+    case 2:
+        return spdlog::level::info;
+    case 3:
+        return spdlog::level::warn;
+    case 4:
+        return spdlog::level::err;
+    case 5:
+        return spdlog::level::critical;
+    case 6:
+    default:
+        return spdlog::level::off;
+    }
+}
 
 extern "C" {
 
@@ -109,9 +119,7 @@ void AFF4_set_verbosity(unsigned int level) {
     Holder&h = get_holder();
     h.log->reset();
 
-    const spdlog::level::level_enum e =
-        level >= sizeof(LEVEL_TO_ENUM)/sizeof(LEVEL_TO_ENUM[0]) ?
-        spdlog::level::off : LEVEL_TO_ENUM[level];
+    const spdlog::level::level_enum e = enum_for_level(level);
     h.resolver.logger->set_level(e);
     h.resolver.logger->debug(
         "Set logging level to {}", spdlog::level::to_str(e)

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -73,7 +73,7 @@ struct Holder {
         )
     {}
 
-    bool getHandle(int handle, aff4::URN& urn) {
+    bool getURN(int handle, aff4::URN& urn) {
         const auto& it = handles.find(handle);
         if (it == handles.end()) {
             return false;
@@ -186,7 +186,7 @@ uint64_t AFF4_object_size(int handle) {
     h.log->reset();
 
     aff4::URN urn;
-    if (h.getHandle(handle, urn)) {
+    if (h.getURN(handle, urn)) {
         auto stream = h.resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
         if (stream.get()) {
             return stream->Size();
@@ -200,8 +200,7 @@ int AFF4_read(int handle, uint64_t offset, void* buffer, int length) {
     h.log->reset();
 
     aff4::URN urn;
-
-    if (!h.getHandle(handle, urn)) return -1;
+    if (!h.getURN(handle, urn)) return -1;
 
     auto stream = h.resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
     int read = 0;
@@ -221,7 +220,7 @@ int AFF4_close(int handle) {
     h.log->reset();
 
     aff4::URN urn;
-    if (h.getHandle(handle, urn)) {
+    if (h.getURN(handle, urn)) {
         auto obj = h.resolver.AFF4FactoryOpen<aff4::AFF4Object>(urn);
         if (obj.get()) {
             h.resolver.Close(obj);

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -14,47 +14,97 @@
 */
 
 #include <cstring>
+#include <memory>
+#include <sstream>
+#include <unordered_map>
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/ostream_sink.h>
+
 #include "aff4/lexicon.h"
 #include "aff4/libaff4.h"
 #include "aff4/libaff4-c.h"
 
-aff4::MemoryDataStore& get_resolver() {
-    // The application resolver
-    static aff4::MemoryDataStore resolver;
-    return resolver;
+struct Holder {
+    Holder():
+        resolver(
+            aff4::DataStoreOptions{
+                spdlog::create(
+                    "aff4",
+                     std::make_shared<spdlog::sinks::ostream_sink_mt>(logstream)
+                ),
+                1
+            }
+        )
+    {}
+
+    bool getHandle(int handle, aff4::URN& urn) {
+        const auto& it = handles.find(handle);
+        if (it == handles.end()) {
+            return false;
+        }
+        urn = it->second;
+        return true;
+    }
+
+    std::string getLog() { return logstream.str(); }
+
+    void resetLog() { logstream.str(""); }
+
+    std::ostringstream logstream;
+    aff4::MemoryDataStore resolver;
+    std::unordered_map<int, aff4::URN> handles;
+    int nextHandle = 0;
+};
+
+Holder& get_holder() {
+    static Holder the_holder;
+    return the_holder;
 }
 
-// The next handle.
-static int nextHandle = 0;
-
-std::unordered_map<int, aff4::URN>& get_handles() {
-    // The map of handles to AFF4 Map instances.
-    static std::unordered_map<int, aff4::URN> handles;
-    return handles;
-}
-
-bool GetHandle(int handle, aff4::URN *urn) {
-    auto& handles = get_handles();
-    const auto& it = handles.find(handle);
-    if (it == handles.end())
-        return false;
-
-    *urn = it->second;
-
-    return true;
-}
-
+const spdlog::level::level_enum LEVEL_TO_ENUM[] = {
+  spdlog::level::trace,
+  spdlog::level::debug,
+  spdlog::level::info,
+  spdlog::level::warn,
+  spdlog::level::err,
+  spdlog::level::critical,
+  spdlog::level::off
+};
 
 extern "C" {
 
-void AFF4_init() {
+void AFF4_verbosity(unsigned int level) {
+    Holder&h = get_holder();
+    h.resetLog();
+
+    const spdlog::level::level_enum e = level >= sizeof(LEVEL_TO_ENUM)/sizeof(LEVEL_TO_ENUM[0]) ? spdlog::level::off : LEVEL_TO_ENUM[level];
+    h.resolver.logger->set_level(e);
+    h.resolver.logger->debug(
+        "Set logging level to {}", spdlog::level::to_str(e)
+    );
+}
+
+char* AFF4_message() {
+    Holder&h = get_holder();
+    const std::string logstr = h.getLog();
+    h.resetLog();
+    char* msg = new char[logstr.length()+1];
+    std::strcpy(msg, logstr.c_str());
+    return msg;
+}
+
+void AFF4_message_free(char* msg) {
+    delete[] msg;
 }
 
 int AFF4_open(char* filename) {
-    aff4::MemoryDataStore& resolver = get_resolver();
+    Holder& h = get_holder();
+    h.resetLog();
+
     aff4::URN urn = aff4::URN::NewURNFromFilename(filename);
     aff4::AFF4ScopedPtr<aff4::ZipFile> zip = aff4::ZipFile::NewZipFile(
-        &resolver, urn);
+        &h.resolver, urn);
     if (!zip) {
         errno = ENOENT;
         return -1;
@@ -62,13 +112,13 @@ int AFF4_open(char* filename) {
 
     // Attempt AFF4 Standard, and if not, fallback to AFF4 Evimetry Legacy format.
     const aff4::URN type(aff4::AFF4_IMAGE_TYPE);
-    std::unordered_set<aff4::URN> images = resolver.Query(aff4::AFF4_TYPE, &type);
+    std::unordered_set<aff4::URN> images = h.resolver.Query(aff4::AFF4_TYPE, &type);
 
     if (images.empty()) {
         const aff4::URN legacy_type(aff4::AFF4_LEGACY_IMAGE_TYPE);
-        images = resolver.Query(aff4::URN(aff4::AFF4_TYPE), &legacy_type);
+        images = h.resolver.Query(aff4::URN(aff4::AFF4_TYPE), &legacy_type);
         if (images.empty()) {
-            resolver.Close(zip);
+            h.resolver.Close(zip);
             errno = ENOENT;
             return -1;
         }
@@ -80,29 +130,31 @@ int AFF4_open(char* filename) {
 
     // Make sure we only load an image that is stored in the filename provided
     for (const auto & image : sorted_images) {
-        if (!resolver.HasURNWithAttributeAndValue(image, aff4::AFF4_STORED, zip->urn)) {
+        if (!h.resolver.HasURNWithAttributeAndValue(image, aff4::AFF4_STORED, zip->urn)) {
             continue;
         }
 
-        if(!resolver.AFF4FactoryOpen<aff4::AFF4StdImage>(image)) {
+        if (!h.resolver.AFF4FactoryOpen<aff4::AFF4StdImage>(image)) {
             continue;
         }
 
-        const int handle = nextHandle++;
-        get_handles()[handle] = image;
+        const int handle = h.nextHandle++;
+        h.handles[handle] = image;
         return handle;
     }
 
-    resolver.Close(zip);
+    h.resolver.Close(zip);
     errno = ENOENT;
     return -1;
 }
 
 uint64_t AFF4_object_size(int handle) {
-    aff4::MemoryDataStore& resolver = get_resolver();
+    Holder& h = get_holder();
+    h.resetLog();
+
     aff4::URN urn;
-    if (GetHandle(handle, &urn)) {
-        auto stream = resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
+    if (h.getHandle(handle, urn)) {
+        auto stream = h.resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
         if (stream.get()) {
             return stream->Size();
         }
@@ -111,12 +163,14 @@ uint64_t AFF4_object_size(int handle) {
 }
 
 int AFF4_read(int handle, uint64_t offset, void* buffer, int length) {
-    aff4::MemoryDataStore& resolver = get_resolver();
+    Holder& h = get_holder();
+    h.resetLog();
+
     aff4::URN urn;
 
-    if (!GetHandle(handle, &urn)) return -1;
+    if (!h.getHandle(handle, urn)) return -1;
 
-    auto stream = resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
+    auto stream = h.resolver.AFF4FactoryOpen<aff4::AFF4Stream>(urn);
     int read = 0;
     if (stream.get()) {
         stream->Seek(offset, SEEK_SET);
@@ -130,13 +184,15 @@ int AFF4_read(int handle, uint64_t offset, void* buffer, int length) {
 }
 
 int AFF4_close(int handle) {
-    aff4::MemoryDataStore& resolver = get_resolver();
+    Holder& h = get_holder();
+    h.resetLog();
+
     aff4::URN urn;
-    if (GetHandle(handle, &urn)) {
-        auto obj = resolver.AFF4FactoryOpen<aff4::AFF4Object>(urn);
+    if (h.getHandle(handle, urn)) {
+        auto obj = h.resolver.AFF4FactoryOpen<aff4::AFF4Object>(urn);
         if (obj.get()) {
-            resolver.Close(obj);
-            get_handles().erase(handle);
+            h.resolver.Close(obj);
+            h.handles.erase(handle);
         }
     }
     return 0;

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -32,12 +32,14 @@ public:
     }
 
     virtual void log(const spdlog::details::log_msg& msg) override {
-        char* str = new char[msg.formatted.size()+1];
-        std::strncpy(str, msg.formatted.data(), msg.formatted.size());
-        str[msg.formatted.size()] = '\0';
+        // populate our message struct
+        char* str = new char[msg.raw.size()+1];
+        std::strncpy(str, msg.raw.data(), msg.raw.size());
+        str[msg.raw.size()] = '\0';
 
         AFF4_Message* m = new AFF4_Message{msg.level, str, nullptr};
 
+        // append it to the list
         if (tail) {
             tail->next = m;
         }

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -39,17 +39,28 @@ const char* AFF4_version();
 void AFF4_init();
 
 /**
- * Get messages logged since the last call to any C API function other than
- * AFF4_message or AFF4_message_free.
- * @return String containing messsages
+ * The message struct. Follow the next pointer for the next message; the last
+ * message will have a null next pointer. The pointer returned by
+ * AFF4_get_messages() MUST be freed by AFF4_free_messages().
  */
-char* AFF4_message();
+typedef struct AFF4_Message {
+    unsigned int level;
+    char* message;
+    struct AFF4_Message* next;
+} AFF4_Message;
 
 /**
- * Free message string returned by AFF4_message().
- * @param msg The message string pointer
+ * Get messages logged since the last call to any C API function. The message
+ * pointer must be freed with AFF4_free_messages().
+ * @return The message pointer
  */
-void AFF4_message_free(char* msg);
+AFF4_Message* AFF4_get_messages();
+
+/**
+ * Free message list returned by AFF4_get_messages().
+ * @param msg The message pointer
+ */
+void AFF4_free_messages(AFF4_Message* msg);
 
 /**
  * Set the verbosity level for logging.
@@ -64,7 +75,7 @@ void AFF4_message_free(char* msg);
  *
  * @param level The verbosity level
  */
-void AFF4_verbosity(unsigned int level);
+void AFF4_set_verbosity(unsigned int level);
 
 /**
  * Open the given filename, and access the first aff4:Image in the container.

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -39,6 +39,34 @@ const char* AFF4_version();
 void AFF4_init();
 
 /**
+ * Get messages logged since the last call to any C API function other than
+ * AFF4_message or AFF4_message_free.
+ * @return String containing messsages
+ */
+char* AFF4_message();
+
+/**
+ * Free message string returned by AFF4_message().
+ * @param msg The message string pointer
+ */
+void AFF4_message_free(char* msg);
+
+/**
+ * Set the verbosity level for logging.
+ * Levels are:
+ *    0 trace
+ *    1 debug
+ *    2 info
+ *    3 warning
+ *    4 error
+ *    5 critical
+ *    6 off
+ *
+ * @param level The verbosity level
+ */
+void AFF4_verbosity(unsigned int level);
+
+/**
  * Open the given filename, and access the first aff4:Image in the container.
  * @param filename The filename to open.
  * @return Object handle, or -1 on error. See errno

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -40,8 +40,8 @@ void AFF4_init();
 
 /**
  * The message struct. Follow the next pointer for the next message; the last
- * message will have a null next pointer. The pointer returned by
- * AFF4_get_messages() MUST be freed by AFF4_free_messages().
+ * message will have a null next pointer. Every AFF4_Message* produced by the
+ * C API MUST be freed by AFF4_free_messages().
  */
 typedef struct AFF4_Message {
     unsigned int level;
@@ -50,14 +50,7 @@ typedef struct AFF4_Message {
 } AFF4_Message;
 
 /**
- * Get messages logged since the last call to any C API function. The message
- * pointer must be freed with AFF4_free_messages().
- * @return The message pointer
- */
-AFF4_Message* AFF4_get_messages();
-
-/**
- * Free message list returned by AFF4_get_messages().
+ * Free message list.
  * @param msg The message pointer
  */
 void AFF4_free_messages(AFF4_Message* msg);
@@ -80,14 +73,15 @@ void AFF4_set_verbosity(unsigned int level);
 /**
  * Open the given filename, and access the first aff4:Image in the container.
  * @param filename The filename to open.
+ * @param msg A pointer to log messages.
  * @return Object handle, or -1 on error. See errno
  */
-int AFF4_open(char* filename);
+int AFF4_open(const char* filename, AFF4_Message** msg);
 
 /**
  * Get the size of the AFF4 Object that was opened.
  */
-uint64_t AFF4_object_size(int handle);
+uint64_t AFF4_object_size(int handle, AFF4_Message** msg);
 
 /**
  * Read a block from the given handle.
@@ -95,15 +89,18 @@ uint64_t AFF4_object_size(int handle);
  * @param offset the offset into the stream
  * @param buffer Pointer to a buffer of length.
  * @param length The length of the buffer to fill.
+ * @param msg A pointer to log messages.
  * @return The number of bytes placed into the buffer.
  */
-int AFF4_read(int handle, uint64_t offset, void* buffer, int length);
+int AFF4_read(int handle, uint64_t offset, void* buffer, int length, AFF4_Message** msg);
 
 /**
  * Close the given handle.
  * @param handle The Object handle to close.
+ * @param msg A pointer to log messages.
+ * @return 0, or -1 on error.
  */
-int AFF4_close(int handle);
+int AFF4_close(int handle, AFF4_Message** msg);
 
 #ifdef __cplusplus
 }

--- a/tests/aff4_capi.cc
+++ b/tests/aff4_capi.cc
@@ -20,7 +20,7 @@
 namespace aff4 {
 
 
-void printBuffer(char* buffer, int size) {
+void printBuffer(const char* buffer, int size) {
     for (int i = 0; i < size; i++) {
         if (i > 0) {
             printf(":");
@@ -42,79 +42,76 @@ TEST_F(AFF4CAPI, Sample1URN) {
 
     AFF4_init();
 
-    int handle = AFF4_open(const_cast<char*>(filename.c_str()));
+    int handle = AFF4_open(filename.c_str(), nullptr);
     ASSERT_NE(-1, handle);
 
-    uint64_t size = AFF4_object_size(handle);
+    uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    void* buffer = malloc(32);
+    char* buffer = (char*) malloc(32);
     memset(buffer, 0, 32);
-    int read = AFF4_read(handle, 0, buffer, 32);
+    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
 
-    printBuffer((char*) buffer, 32);
+    printBuffer(buffer, 32);
     free(buffer);
-    AFF4_close(handle);
-
+    AFF4_close(handle, nullptr);
 }
 
 TEST_F(AFF4CAPI, Sample2URN) {
     std::string filename = reference_images + "AFF4Std/Base-Allocated.aff4";
     AFF4_init();
 
-    int handle = AFF4_open(const_cast<char*>(filename.c_str()));
+    int handle = AFF4_open(filename.c_str(), nullptr);
     ASSERT_NE(-1, handle);
 
-    uint64_t size = AFF4_object_size(handle);
+    uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    void* buffer = malloc(32);
+    char* buffer = (char*) malloc(32);
     memset(buffer, 0, 32);
 
     // Start
-    int read = AFF4_read(handle, 0, buffer, 32);
+    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer((char*) buffer, 32);
+    printBuffer(buffer, 32);
 
     // Unreadable
     memset(buffer, 0, 32);
-    read = AFF4_read(handle, 32326 * 512, buffer, 32);
+    read = AFF4_read(handle, 32326 * 512, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer((char*) buffer, 32);
+    printBuffer(buffer, 32);
 
     free(buffer);
-    AFF4_close(handle);
-
+    AFF4_close(handle, nullptr);
 }
 
 TEST_F(AFF4CAPI, Sample3URN) {
     std::string filename = reference_images + "AFF4Std/Base-Linear-ReadError.aff4";
     AFF4_init();
 
-    int handle = AFF4_open(const_cast<char*>(filename.c_str()));
+    int handle = AFF4_open(filename.c_str(), nullptr);
     ASSERT_NE(-1, handle);
 
-    uint64_t size = AFF4_object_size(handle);
+    uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    void* buffer = malloc(32);
+    char* buffer = (char*) malloc(32);
     memset(buffer, 0, 32);
 
     // Start...
-    int read = AFF4_read(handle, 0, buffer, 32);
+    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer((char*) buffer, 32);
+    printBuffer(buffer, 32);
 
     // Unreadable
     memset(buffer, 0, 32);
-    read = AFF4_read(handle, 32326 * 512, buffer, 32);
+    read = AFF4_read(handle, 32326 * 512, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer((char*) buffer, 32);
+    printBuffer(buffer, 32);
 
     free(buffer);
-    AFF4_close(handle);
-
+    AFF4_close(handle, nullptr);
 }
 
 } // namespace aff4


### PR DESCRIPTION
This adds:

* `AFF4_set_verbosity()` for controlling logging level,
* The `AFF4_Message` struct for holding log messages,
* `AFF4_free_messages()` for freeing log messages,
* an `AFF4_Message**` argument to each preexisting C API function for returning messages.
