### PR TITLE
Fix failing tests

### DIFF
--- a/aff4/aff4_directory.cc
+++ b/aff4/aff4_directory.cc
@@ -75,8 +75,8 @@ AFF4ScopedPtr<AFF4Stream> AFF4Directory::CreateMember(URN child) {
         return AFF4ScopedPtr<AFF4Stream>();
     }
 
-    // Use this filename. Note that since filesystems can not typically represent
-    // files and directories as the same path component we can not allow slashes
+    // Use this filename. Note that since filesystems cannot typically represent
+    // files and directories as the same path component we cannot allow slashes
     // in the filename. Otherwise we will fail to create e.g. stream/0000000 and
     // stream/0000000.index.
     std::string filename = member_name_for_urn(child, urn, false);

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -151,7 +151,7 @@ AFF4Status FileBackedObject::LoadFromURN() {
 
     if (fd == INVALID_HANDLE_VALUE) {
         resolver->logger->error(
-            "Can not open file {} : {}", filename,
+            "Cannot open file {} : {}", filename,
             GetLastErrorMessage());
 
         return IO_ERROR;
@@ -332,7 +332,7 @@ AFF4Status FileBackedObject::LoadFromURN() {
               S_IRWXU | S_IRWXG | S_IRWXO);
 
     if (fd < 0) {
-        resolver->logger->error("Can not open file {}: {}", filename,
+        resolver->logger->error("Cannot open file {}: {}", filename,
                                 GetLastErrorMessage());
         return IO_ERROR;
     }
@@ -389,7 +389,7 @@ AFF4Status FileBackedObject::Write(const char* data, size_t length) {
         return IO_ERROR;
     }
 
-    // Since all file operations are synchronous this object can not be dirty.
+    // Since all file operations are synchronous this object cannot be dirty.
     if (properties.seekable) {
         lseek(fd, readptr, SEEK_SET);
     }

--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -453,7 +453,7 @@ AFF4Status BasicImager::process_input() {
 AFF4Status BasicImager::handle_export() {
     if (Get("output")->isSet()) {
         resolver.logger->error(
-            "Can not specify an export and an output volume at the same time "
+            "Cannot specify an export and an output volume at the same time "
             "(did you mean --export_dir).");
         return INVALID_INPUT;
     }

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -156,7 +156,7 @@ std::string AFF4Map::Read(size_t length) {
                 // due to Virtual Secure Mode (VSM) memory. Re-read memory in smaller units,
                 // while leaving the unreadable regions null-padded.
                 resolver->logger->info(
-                    "Map target {} can not produced required {} bytes at offset 0x{:x}. Got {} bytes. Will re-read one page at a time.",
+                    "Map target {} cannot produced required {} bytes at offset 0x{:x}. Got {} bytes. Will re-read one page at a time.",
                     target_stream->urn.SerializeToString(),
                     length_to_read_in_target, offset_in_target, data.size());
 

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -324,6 +324,10 @@ class DataStore {
     DataStore(DataStoreOptions options);
     virtual ~DataStore() {}
 
+    DataStore(DataStore&&) = default;
+
+    DataStore& operator=(DataStore&&) = default;
+
     // All logging directives go through this handle. It can be
     // replaced with a different handler if needed.
     std::shared_ptr<spdlog::logger> logger;
@@ -630,6 +634,10 @@ class MemoryDataStore: public DataStore {
 
   public:
     MemoryDataStore() = default;
+
+    MemoryDataStore(MemoryDataStore&&) = default;
+
+    MemoryDataStore& operator=(MemoryDataStore&&) = default;
 
     MemoryDataStore(DataStoreOptions options): DataStore(options) {}
 

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -85,8 +85,8 @@ struct AFF4ObjectCacheEntry {
     ~AFF4ObjectCacheEntry() {
         unlink();
 
-        // We can not call Flush on destruction because Flushing an object might try
-        // to access another object in the cache, which we can not guarantee is not
+        // We cannot call Flush on destruction because Flushing an object might try
+        // to access another object in the cache, which we cannot guarantee is not
         // already destroyed. Therefore we destroy the cache in two passes - first
         // we call Flush on all objects, then we destroy all objects without calling
         // their Flush methods.
@@ -110,7 +110,7 @@ class AFF4ObjectCache {
     std::shared_ptr<spdlog::logger> logger;
 
     // When objects are returned from Get() they are placed on this map. This
-    // ensures that they can not be deleted while in use. When objects are
+    // ensures that they cannot be deleted while in use. When objects are
     // returned to the cache with Return() they are placed in the normal lru.
     std::unordered_map<std::string, AFF4ObjectCacheEntry*> in_use;
     std::unordered_map<std::string, AFF4ObjectCacheEntry*> lru_map;
@@ -119,7 +119,7 @@ class AFF4ObjectCache {
     /**
      *   Trim the size of the cache if needed.
      *
-     * @return STATUS_OK if flushing objects is successful. Objects which can not
+     * @return STATUS_OK if flushing objects is successful. Objects which cannot
      * be flushed are not removed from the cache.
      */
     AFF4Status Trim_();
@@ -181,7 +181,7 @@ class AFF4ObjectCache {
      * @param urn
      *
      * @return STATUS_OK if Flushing the object worked. If there is an error the
-     * object can not be removed from the cache.
+     * object cannot be removed from the cache.
      */
     AFF4Status Remove(AFF4Object* object);
 

--- a/aff4/lexicon.inc
+++ b/aff4/lexicon.inc
@@ -205,7 +205,7 @@ LEXICON_DEFINE(AFF4_CONSTANT_CHAR, "http://aff4.org/Schema#constant_char");
 LEXICON_DEFINE(AFF4_DIRECTORY_TYPE, "http://aff4.org/Schema#directory");
 
 // An AFF4 Directory stores all members as files on the filesystem. Some
-// filesystems can not represent the URNs properly, hence we need a mapping
+// filesystems cannot represent the URNs properly, hence we need a mapping
 // between the URN and the filename. This attribute stores the _relative_ path
 // of the filename for the member URN relative to the container's path.
 LEXICON_DEFINE(AFF4_DIRECTORY_CHILD_FILENAME, "http://aff4.org/Schema#directory/filename");

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -225,6 +225,7 @@ int AFF4_read(int handle, uint64_t offset, void* buffer, int length, AFF4_Messag
         std::memcpy(buffer, result.data(), read);
     } else {
         errno = ENOENT;
+        return -1;
     }
     return read;
 }

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -80,11 +80,7 @@ public:
 
 struct Holder {
     Holder():
-        resolver(
-            aff4::DataStoreOptions{
-                spdlog::create("aff4", std::make_shared<LogSink>()), 1
-            }
-        )
+        resolver(Holder::make_resolver())
     {
         resolver.logger->set_level(spdlog::level::err);
     }
@@ -96,6 +92,15 @@ struct Holder {
         }
         urn = it->second;
         return true;
+    }
+
+    static aff4::MemoryDataStore make_resolver() {
+        spdlog::drop("aff4");
+        return aff4::MemoryDataStore(
+            aff4::DataStoreOptions{
+                spdlog::create("aff4", std::make_shared<LogSink>()), 1
+            }
+        );
     }
 
     aff4::MemoryDataStore resolver;

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -105,7 +105,7 @@ AFF4Status AFF4Stream::Seek(off_t offset, int whence) {
         new_offset += offset;
 
     } else if (whence == 2) {
-        // We can not seek relative to size for streams which are non sizeable.
+        // We cannot seek relative to size for streams which are non sizeable.
         if (!properties.sizeable) {
             return IO_ERROR;
         }

--- a/tests/aff4_capi.cc
+++ b/tests/aff4_capi.cc
@@ -33,7 +33,7 @@ void printBuffer(const char* buffer, int size) {
 
 class AFF4CAPI : public ::testing::Test {
 protected:
-    const std::string reference_images = "tests/ReferenceImages/";
+    const std::string reference_images = "ReferenceImages/";
 };
 
 
@@ -52,8 +52,8 @@ TEST_F(AFF4CAPI, Sample1URN) {
     memset(buffer, 0, 32);
     int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
+    ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
-    printBuffer(buffer, 32);
     free(buffer);
     AFF4_close(handle, nullptr);
 }
@@ -74,13 +74,13 @@ TEST_F(AFF4CAPI, Sample2URN) {
     // Start
     int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer(buffer, 32);
+    ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
     // Unreadable
     memset(buffer, 0, 32);
     read = AFF4_read(handle, 32326 * 512, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer(buffer, 32);
+    ASSERT_STREQ("\x4D\xD9\x8B\x8C\xE2\x39\x44\x58\x6B\xA2\xA8\xDB\x04\x1C\x6D\x36\x81\x41\x36\x8B\x90\xA7\x16\xC2\x5E\x9A\x0C\xA6\xE6\xD9\x0B\x7E", buffer);
 
     free(buffer);
     AFF4_close(handle, nullptr);
@@ -102,13 +102,13 @@ TEST_F(AFF4CAPI, Sample3URN) {
     // Start...
     int read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer(buffer, 32);
+    ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
     // Unreadable
     memset(buffer, 0, 32);
     read = AFF4_read(handle, 32326 * 512, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
-    printBuffer(buffer, 32);
+    ASSERT_STREQ("\x55\x4E\x52\x45\x41\x44\x41\x42\x4C\x45\x44\x41\x54\x41\x55\x4E\x52\x45\x41\x44\x41\x42\x4C\x45\x44\x41\x54\x41\x55\x4E\x52\x45", buffer);
 
     free(buffer);
     AFF4_close(handle, nullptr);

--- a/tests/aff4_image_test.cc
+++ b/tests/aff4_image_test.cc
@@ -22,7 +22,7 @@ namespace aff4 {
 
 class AFF4ImageTest: public ::testing::Test {
  protected:
-  std::string filename = "/tmp/aff4_test.zip";
+  std::string filename = "file:///tmp/aff4_test.zip";
   std::string image_name = "image.dd";
   URN volume_urn;
   URN image_urn;
@@ -31,7 +31,7 @@ class AFF4ImageTest: public ::testing::Test {
 
   // Remove the file on teardown.
   virtual void TearDown() {
-      unlink(filename.c_str());
+      unlink(filename.c_str() + 7);
   }
 
   // Create an AFF4Image stream with some data in it.

--- a/tests/aff4tests.cc
+++ b/tests/aff4tests.cc
@@ -12,10 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <spdlog/spdlog.h>
+
 #include <gtest/gtest.h>
 #include <glog/logging.h>
 
 int main(int argc, char* argv[]) {
+  // turn off logging to suppress noise
+  spdlog::set_level(spdlog::level::off);
+  // turn on logging to see what's happening
+//  spdlog::set_level(spdlog::level::debug);
+
   ::testing::InitGoogleTest(&argc, argv);
 
   return RUN_ALL_TESTS();

--- a/tests/rdf_tests.cc
+++ b/tests/rdf_tests.cc
@@ -32,6 +32,10 @@ TEST(URNTest, SerializeURN) {
       "/etc/passwd").SerializeToString(), "file:///etc/passwd");
 #endif
 
+#ifdef _WIN32
+  // FIXME: Due to a bug in uriparser handling of relative paths, we currently
+  // force all UNIX path names to be absolute.
+
   // Relative paths are relative to the current working directory.
   {
     char cwd[1024];
@@ -52,6 +56,7 @@ TEST(URNTest, SerializeURN) {
     EXPECT_EQ(URN("etc/passwd").SerializeToString(),
                 std::string("file://") + cwd_string + "/etc/passwd");
   };
+#endif
 }
 
 
@@ -80,7 +85,9 @@ TEST(URNTest, Append) {
             "http://www.google.com/aa/c");
 }
 
-
+#ifdef _WIN32
+// FIXME: Due to a bug in uriparser handling of relative paths, we currently
+// force all UNIX path names to be absolute.
 TEST(URNTest, RelativePath) {
   URN parent("aff4://e21659ea-c7d6-4f4d-8070-919178aa4c7b");
   URN child(
@@ -89,6 +96,7 @@ TEST(URNTest, RelativePath) {
 
   EXPECT_EQ(parent.RelativePath(child), "/bin/ls/00000000/index");
 }
+#endif
 
 // Test that XSDInteger can accomodate very large values.
 TEST(XSDIntegerTest, SerializeToString) {

--- a/tests/rdfquery_test.cc
+++ b/tests/rdfquery_test.cc
@@ -23,7 +23,7 @@ namespace aff4 {
 
 class AFF4ImageRDFQuery : public ::testing::Test {
 protected:
-    const std::string reference_images = "tests/ReferenceImages/";
+    const std::string reference_images = "ReferenceImages/";
 };
 
 

--- a/tests/zip_test.cc
+++ b/tests/zip_test.cc
@@ -21,7 +21,7 @@ namespace aff4 {
 
 class ZipTest: public ::testing::Test {
  protected:
-        std::string filename = "/tmp/aff4_test.zip";
+        std::string filename = "file:///tmp/aff4_test.zip";
         std::string segment_name = "Foobar.txt";
         std::string data1 = "I am a segment!";
         std::string data2 = "I am another segment!";

--- a/tools/pmem/osxpmem.cc
+++ b/tools/pmem/osxpmem.cc
@@ -216,7 +216,7 @@ AFF4Status OSXPmemImager::ParseArgs() {
   if (result == CONTINUE && Get("load-driver")->isSet() &&
       Get("unload-driver")->isSet()) {
       resolver.logger->critical(
-          "You can not specify both the -l and -u options together.");
+          "You cannot specify both the -l and -u options together.");
     return INVALID_INPUT;
   }
 
@@ -277,12 +277,12 @@ std::string OSXPmemImager::get_driver_path() {
 
 void OSXPmemImager::fix_path(const std::string& path, mode_t mode) {
     if (lchown(path.c_str(), 0, 0) != 0) {
-        resolver.logger->info("Can not chown {} ({}). Driver may not load.",
+        resolver.logger->info("Cannot chown {} ({}). Driver may not load.",
                               path, strerror(errno));
     }
 
     if (chmod(path.c_str(), 07700 & mode) != 0) {
-        resolver.logger->info("Can not chmod {} ({}). Driver may not load.",
+        resolver.logger->info("Cannot chmod {} ({}). Driver may not load.",
                               path, strerror(errno));
     }
 }

--- a/tools/pmem/pmem.h
+++ b/tools/pmem/pmem.h
@@ -102,7 +102,7 @@ class PmemImager: public BasicImager {
         AddArg(new TCLAP::MultiArgToNextFlag(
                    "p", "pagefile", "Also capture the pagefile. Note that you must "
                    "provide this option rather than e.g. '--input c:\\pagefile.sys' "
-                   "because we can not normally read the pagefile directly. This "
+                   "because we cannot normally read the pagefile directly. This "
                    "option will use the sleuthkit to read the pagefile.",
                    false, "/path/to/pagefile"));
 

--- a/tools/pmem/pmem_imager.cc
+++ b/tools/pmem/pmem_imager.cc
@@ -301,7 +301,7 @@ AFF4ScopedPtr<AFF4Stream> PmemImager::GetWritableStream_(
             output_volume_backing_urn = URN("builtin://stdout");
         }
 
-        // Flat files can not store more than one stream so we must
+        // Flat files cannot store more than one stream so we must
         // truncate them.
         resolver.Set(output_volume_backing_urn,
                      AFF4_STREAM_WRITE_MODE, new XSDString("truncate"));
@@ -336,7 +336,7 @@ AFF4ScopedPtr<AFF4Stream> PmemImager::GetWritableStream_(
 AFF4Status PmemImager::process_input() {
     if (volume_type != "aff4") {
         resolver.logger->info(
-            "Output volume is not an AFF4 file. Can not capture additional streams. "
+            "Output volume is not an AFF4 file. Cannot capture additional streams. "
             "Choose an AFF4 volume to capture additional streams.");
         return STATUS_OK;
     }

--- a/tools/pmem/win_pmem.cc
+++ b/tools/pmem/win_pmem.cc
@@ -153,7 +153,7 @@ AFF4Status WinPmemImager::GetMemoryInfo(PmemMemoryInfo *info) {
       <FileBackedObject>(device_urn);
 
   if (!device_stream) {
-      resolver.logger->error("Can not open device {}", device_urn);
+      resolver.logger->error("Cannot open device {}", device_urn);
       return IO_ERROR;
   }
 
@@ -647,7 +647,7 @@ AFF4Status WinPmemImager::_InstallDriver(std::string driver_path) {
 
   SC_HANDLE scm = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
   if (!scm) {
-      resolver.logger->error("Can not open SCM. Are you administrator?");
+      resolver.logger->error("Cannot open SCM. Are you administrator?");
       return IO_ERROR;
   }
 
@@ -710,7 +710,7 @@ AFF4Status WinPmemImager::InstallDriver() {
     // and when not to - We try to load the attestation signed ones
     // first, and if that fails we try the other ones. On modern win10
     // systems the attestation signed drivers are required, while on
-    // windows 7 they can not be loaded.
+    // windows 7 they cannot be loaded.
     URN filename_urn = URN::NewURNFromFilename(driver_path);
     size_t file_size;
     const unsigned char* file_contents = GetDriverAtt(resolver, &file_size);
@@ -821,7 +821,7 @@ AFF4Status WinPmemImager::ParseArgs() {
   // Sanity checks.
   if (result == CONTINUE && Get("load-driver")->isSet() &&
       Get("unload-driver")->isSet()) {
-      resolver.logger->error("You can not specify both the -l and -u options together.");
+      resolver.logger->error("You cannot specify both the -l and -u options together.");
     return INVALID_INPUT;
   }
 


### PR DESCRIPTION
This fixes the problems noted in Issue #68.

* DataStore::AFF4FactoryOpen() wants a string which is a URN, not just a path; /tmp/aff4_test.zip -> file:///tmp/aff4_test.zip
* 'make check' runs tests from tests/; adjust reference images path to match.
* Assert that the data read is what's expected instead of just dumping it to STDOUT.
* Added move ctor and operator= to DataStore and MemoryDataStore so that we can reset the aff4 logger during the initialization of the C API's resolver.
* "cannot" is one word.
* Turn off logging for tests to suppress noise (but leave commented line for turning logging back on in case of problems).
* Disable relative path tests on Unix while relative path parsing is disabled on Unix.

