### PR TITLE
Assorted cleanup

### DIFF
--- a/aff4/aff4_base.h
+++ b/aff4/aff4_base.h
@@ -155,7 +155,7 @@ class AFF4Object {
      *
      * @return true if the object is dirty.
      */
-    virtual bool IsDirty() {
+    virtual bool IsDirty() const {
         return _dirty;
     }
 

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -79,13 +79,15 @@ class AFF4ConstantStream: public AFF4Stream {
   public:
     explicit AFF4ConstantStream(DataStore* resolver): AFF4Stream(resolver) {}
 
-    aff4_off_t Size() override {
+    virtual aff4_off_t Size() const override {
         return -1;
     }
+
     AFF4Status LoadFromURN() override {
         size = Size();
         return STATUS_OK;
     }
+
     std::string Read(size_t length) override {
         return std::string(length, constant);
     }

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -79,7 +79,7 @@ class AFF4ConstantStream: public AFF4Stream {
   public:
     explicit AFF4ConstantStream(DataStore* resolver): AFF4Stream(resolver) {}
 
-    virtual aff4_off_t Size() const override {
+    aff4_off_t Size() const override {
         return -1;
     }
 

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -23,29 +23,29 @@ specific language governing permissions and limitations under the License.
 namespace aff4 {
 
 
-AFF4Status CompressZlib_(const std::string &input, std::string& output) {
+AFF4Status CompressZlib_(const std::string &input, std::string* output) {
     uLongf c_length = compressBound(input.size()) + 1;
-    output.resize(c_length);
+    output->resize(c_length);
 
-    if (compress2(reinterpret_cast<Bytef*>(&output[0]),
+    if (compress2(reinterpret_cast<Bytef*>(&(*output)[0]),
                   &c_length,
                   reinterpret_cast<Bytef*>(const_cast<char*>(input.data())),
                   input.size(), 1) != Z_OK) {
         return MEMORY_ERROR;
     }
 
-    output.resize(c_length);
+    output->resize(c_length);
 
     return STATUS_OK;
 }
 
-AFF4Status DeCompressZlib_(const std::string &input, std::string& output) {
-    uLongf buffer_size = output.size();
+AFF4Status DeCompressZlib_(const std::string &input, std::string* output) {
+    uLongf buffer_size = output->size();
 
-    if (uncompress(reinterpret_cast<Bytef*>(&output[0]),
+    if (uncompress(reinterpret_cast<Bytef*>(&(*output)[0]),
                    &buffer_size,
                    (const Bytef*)input.data(), input.size()) == Z_OK) {
-        output.resize(buffer_size);
+        output->resize(buffer_size);
         return STATUS_OK;
     }
 
@@ -53,15 +53,15 @@ AFF4Status DeCompressZlib_(const std::string &input, std::string& output) {
 }
 
 
-AFF4Status CompressSnappy_(const std::string &input, std::string& output) {
-    snappy::Compress(input.data(), input.size(), &output);
+AFF4Status CompressSnappy_(const std::string &input, std::string* output) {
+    snappy::Compress(input.data(), input.size(), output);
 
     return STATUS_OK;
 }
 
 
-AFF4Status DeCompressSnappy_(const std::string &input, std::string& output) {
-    if (!snappy::Uncompress(input.data(), input.size(), &output)) {
+AFF4Status DeCompressSnappy_(const std::string &input, std::string* output) {
+    if (!snappy::Uncompress(input.data(), input.size(), output)) {
         return GENERIC_ERROR;
     }
 
@@ -148,12 +148,12 @@ private:
 
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB: {
-            RETURN_IF_ERROR(CompressZlib_(data, c_data));
+            RETURN_IF_ERROR(CompressZlib_(data, &c_data));
         }
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY: {
-            RETURN_IF_ERROR(CompressSnappy_(data, c_data));
+            RETURN_IF_ERROR(CompressSnappy_(data, &c_data));
         }
             break;
 
@@ -632,11 +632,11 @@ AFF4Status AFF4Image::ReadChunkFromBevy(
     } else {
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB:
-            res = DeCompressZlib_(cbuffer, buffer);
+            res = DeCompressZlib_(cbuffer, &buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY:
-            res = DeCompressSnappy_(cbuffer, buffer);
+            res = DeCompressSnappy_(cbuffer, &buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_STORED:
@@ -693,7 +693,7 @@ int AFF4Image::_ReadPartial(unsigned int chunk_id, int chunks_to_read,
 
         if (isAFF4Legacy) {
             // Massage the bevvy data format from the old into the new.
-            bevy_index_data = _FixupBevyData(bevy_index_data);
+            bevy_index_data = _FixupBevyData(&bevy_index_data);
             index_size = bevy_index->Size() / sizeof(uint32_t);
         }
 
@@ -800,10 +800,10 @@ static AFF4Registrar<AFF4Image> r2(AFF4_LEGACY_IMAGESTREAM_TYPE);
 
 void aff4_image_init() {}
 
-std::string AFF4Image::_FixupBevyData(std::string& data){
-    const uint32_t index_size = data.length() / sizeof(uint32_t);
+std::string AFF4Image::_FixupBevyData(std::string* data){
+    const uint32_t index_size = data->length() / sizeof(uint32_t);
     std::unique_ptr<BevyIndex[]> bevy_index_array(new BevyIndex[index_size]);
-    uint32_t* bevy_index_data = reinterpret_cast<uint32_t*>(&data[0]);
+    uint32_t* bevy_index_data = reinterpret_cast<uint32_t*>(&(*data)[0]);
 
     uint64_t cOffset = 0;
     uint32_t cLength = 0;

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -72,7 +72,7 @@ AFF4Status DeCompressSnappy_(const std::string &input, std::string* output) {
 AFF4Status CompressLZ4_(const std::string &input, std::string* output) {
     output->resize(LZ4_compressBound(input.size()));
 
-    int size = LZ4_compress_default(input.data(), const_cast<char *>(output->data()),
+    int size = LZ4_compress_default(input.data(), &(*output)[0],
                                     input.size(), output->size());
     if (size == 0) {
         return GENERIC_ERROR;
@@ -85,7 +85,7 @@ AFF4Status CompressLZ4_(const std::string &input, std::string* output) {
 
 
 AFF4Status DeCompressLZ4_(const std::string &input, std::string* output) {
-    int size = LZ4_decompress_safe(input.data(), const_cast<char *>(output->data()),
+    int size = LZ4_decompress_safe(input.data(), &(*output)[0],
                                    input.size(), output->size());
     if (size == 0) {
         return GENERIC_ERROR;

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -23,29 +23,29 @@ specific language governing permissions and limitations under the License.
 namespace aff4 {
 
 
-AFF4Status CompressZlib_(const std::string &input, std::string* output) {
+AFF4Status CompressZlib_(const std::string &input, std::string& output) {
     uLongf c_length = compressBound(input.size()) + 1;
-    output->resize(c_length);
+    output.resize(c_length);
 
-    if (compress2(reinterpret_cast<Bytef*>(const_cast<char*>(output->data())),
+    if (compress2(reinterpret_cast<Bytef*>(&output[0]),
                   &c_length,
                   reinterpret_cast<Bytef*>(const_cast<char*>(input.data())),
                   input.size(), 1) != Z_OK) {
         return MEMORY_ERROR;
     }
 
-    output->resize(c_length);
+    output.resize(c_length);
 
     return STATUS_OK;
 }
 
-AFF4Status DeCompressZlib_(const std::string &input, std::string* output) {
-    uLongf buffer_size = output->size();
+AFF4Status DeCompressZlib_(const std::string &input, std::string& output) {
+    uLongf buffer_size = output.size();
 
-    if (uncompress(reinterpret_cast<Bytef*>(const_cast<char*>(output->data())),
+    if (uncompress(reinterpret_cast<Bytef*>(&output[0]),
                    &buffer_size,
                    (const Bytef*)input.data(), input.size()) == Z_OK) {
-        output->resize(buffer_size);
+        output.resize(buffer_size);
         return STATUS_OK;
     }
 
@@ -53,15 +53,15 @@ AFF4Status DeCompressZlib_(const std::string &input, std::string* output) {
 }
 
 
-AFF4Status CompressSnappy_(const std::string &input, std::string* output) {
-    snappy::Compress(input.data(), input.size(), output);
+AFF4Status CompressSnappy_(const std::string &input, std::string& output) {
+    snappy::Compress(input.data(), input.size(), &output);
 
     return STATUS_OK;
 }
 
 
-AFF4Status DeCompressSnappy_(const std::string &input, std::string* output) {
-    if (!snappy::Uncompress(input.data(), input.size(), output)) {
+AFF4Status DeCompressSnappy_(const std::string &input, std::string& output) {
+    if (!snappy::Uncompress(input.data(), input.size(), &output)) {
         return GENERIC_ERROR;
     }
 
@@ -148,12 +148,12 @@ private:
 
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB: {
-            RETURN_IF_ERROR(CompressZlib_(data, &c_data));
+            RETURN_IF_ERROR(CompressZlib_(data, c_data));
         }
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY: {
-            RETURN_IF_ERROR(CompressSnappy_(data, &c_data));
+            RETURN_IF_ERROR(CompressSnappy_(data, c_data));
         }
             break;
 
@@ -632,11 +632,11 @@ AFF4Status AFF4Image::ReadChunkFromBevy(
     } else {
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB:
-            res = DeCompressZlib_(cbuffer, &buffer);
+            res = DeCompressZlib_(cbuffer, buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY:
-            res = DeCompressSnappy_(cbuffer, &buffer);
+            res = DeCompressSnappy_(cbuffer, buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_STORED:
@@ -693,12 +693,12 @@ int AFF4Image::_ReadPartial(unsigned int chunk_id, int chunks_to_read,
 
         if (isAFF4Legacy) {
             // Massage the bevvy data format from the old into the new.
-            bevy_index_data = _FixupBevyData(&bevy_index_data);
+            bevy_index_data = _FixupBevyData(bevy_index_data);
             index_size = bevy_index->Size() / sizeof(uint32_t);
         }
 
         BevyIndex* bevy_index_array = reinterpret_cast<BevyIndex*>(
-            const_cast<char*>(bevy_index_data.data()));
+            &bevy_index_data[0]);
 
         while (chunks_to_read > 0) {
             // Read a full chunk from the bevy.
@@ -800,10 +800,10 @@ static AFF4Registrar<AFF4Image> r2(AFF4_LEGACY_IMAGESTREAM_TYPE);
 
 void aff4_image_init() {}
 
-std::string AFF4Image::_FixupBevyData(std::string* data){
-    uint32_t index_size = data->length() / sizeof(uint32_t);
-    BevyIndex* bevy_index_array = new BevyIndex[index_size];
-    uint32_t* bevy_index_data = reinterpret_cast<uint32_t*>(const_cast<char*>(data->data()));
+std::string AFF4Image::_FixupBevyData(std::string& data){
+    const uint32_t index_size = data.length() / sizeof(uint32_t);
+    std::unique_ptr<BevyIndex[]> bevy_index_array(new BevyIndex[index_size]);
+    uint32_t* bevy_index_data = reinterpret_cast<uint32_t*>(&data[0]);
 
     uint64_t cOffset = 0;
     uint32_t cLength = 0;
@@ -815,11 +815,10 @@ std::string AFF4Image::_FixupBevyData(std::string* data){
         cOffset += bevy_index_array[offset].length;
     }
 
-    std::string result = std::string(
-        reinterpret_cast<char*>(bevy_index_array),
-        index_size * sizeof(BevyIndex));
-    delete[] bevy_index_array;
-    return result;
+    return std::string(
+        reinterpret_cast<char*>(bevy_index_array.get()),
+        index_size * sizeof(BevyIndex)
+    );
 }
 
 

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -60,10 +60,10 @@ namespace aff4 {
  */
 
 // Compression methods we support.
-AFF4Status CompressZlib_(const char* data, size_t length, std::string& output);
-AFF4Status DeCompressZlib_(const char* data, size_t length, std::string& output);
-AFF4Status CompressSnappy_(const char* data, size_t length, std::string& output);
-AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string& output);
+AFF4Status CompressZlib_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressZlib_(const char* data, size_t length, std::string* output);
+AFF4Status CompressSnappy_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string* output);
 
 
 // This is the type written to the map stream in this exact binary layout.
@@ -81,7 +81,7 @@ class AFF4Image: public AFF4Stream {
     AFF4Status FlushBevy();
 
     // Convert the legecy formatted bevvy data into the new format.
-    std::string _FixupBevyData(std::string& data);
+    std::string _FixupBevyData(std::string* data);
 
     int _ReadPartial(
         unsigned int chunk_id, int chunks_to_read, std::string& result);

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -60,10 +60,10 @@ namespace aff4 {
  */
 
 // Compression methods we support.
-AFF4Status CompressZlib_(const char* data, size_t length, std::string* output);
-AFF4Status DeCompressZlib_(const char* data, size_t length, std::string* output);
-AFF4Status CompressSnappy_(const char* data, size_t length, std::string* output);
-AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string* output);
+AFF4Status CompressZlib_(const char* data, size_t length, std::string& output);
+AFF4Status DeCompressZlib_(const char* data, size_t length, std::string& output);
+AFF4Status CompressSnappy_(const char* data, size_t length, std::string& output);
+AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string& output);
 
 
 // This is the type written to the map stream in this exact binary layout.
@@ -81,7 +81,7 @@ class AFF4Image: public AFF4Stream {
     AFF4Status FlushBevy();
 
     // Convert the legecy formatted bevvy data into the new format.
-    std::string _FixupBevyData(std::string* data);
+    std::string _FixupBevyData(std::string& data);
 
     int _ReadPartial(
         unsigned int chunk_id, int chunks_to_read, std::string& result);

--- a/aff4/aff4_imager_utils.h
+++ b/aff4/aff4_imager_utils.h
@@ -101,11 +101,11 @@ class BasicImager {
     // The list of input streams we copy (from the --inputs flag).
     std::vector<std::string> inputs;
 
-    virtual std::string GetName() {
+    virtual std::string GetName() const {
         return "AFF4 Imager";
     }
 
-    virtual std::string GetVersion() {
+    virtual std::string GetVersion() const {
         return AFF4_VERSION;
     }
 

--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -210,7 +210,7 @@ class StringIO: public AFF4Stream {
     AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status Truncate() override;
-    virtual aff4_off_t Size() const override;
+    aff4_off_t Size() const override;
     void reserve(size_t size) override;
 
     using AFF4Stream::Write;

--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -164,7 +164,7 @@ class AFF4Stream: public AFF4Object {
 
     virtual AFF4Status Write(const char* data, size_t length);
     virtual aff4_off_t Tell();
-    virtual aff4_off_t Size();
+    virtual aff4_off_t Size() const;
 
     // Callers may reserve space in the stream for efficiency. This
     // gives the implementation a hint as to how large this stream is
@@ -203,16 +203,14 @@ class StringIO: public AFF4Stream {
 
     // Convenience constructors.
     static std::unique_ptr<StringIO> NewStringIO() {
-        std::unique_ptr<StringIO> result(new StringIO());
-
-        return result;
+        return std::unique_ptr<StringIO>(new StringIO());
     }
 
     std::string Read(size_t length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status Truncate() override;
-    aff4_off_t Size() override;
+    virtual aff4_off_t Size() const override;
     void reserve(size_t size) override;
 
     using AFF4Stream::Write;

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -195,7 +195,7 @@ std::string AFF4Map::Read(size_t length) {
     return result;
 }
 
-aff4_off_t AFF4Map::Size() {
+aff4_off_t AFF4Map::Size() const {
     // The size of the stream is the end of the last range.
     auto it = map.end();
     if (it == map.begin()) {
@@ -581,7 +581,7 @@ void AFF4Map::Dump() {
 }
 
 
-std::vector<Range> AFF4Map::GetRanges() {
+std::vector<Range> AFF4Map::GetRanges() const {
     std::vector<Range> result;
     for (auto it : map) {
         result.push_back(it.second);

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -41,11 +41,11 @@ class Range: public BinaryRange {
     explicit Range(BinaryRange range): BinaryRange(range) {}
     Range(): BinaryRange() {}
 
-    uint64_t map_end() {
+    uint64_t map_end() const {
         return map_offset + length;
     }
 
-    uint64_t target_end() {
+    uint64_t target_end() const {
         return target_offset + length;
     }
 
@@ -93,14 +93,14 @@ class AFF4Map: public AFF4Stream {
 
     void Dump();
 
-    std::vector<Range> GetRanges();
+    std::vector<Range> GetRanges() const;
 
     // Creates or retrieves the underlying map data stream.
     AFF4Status GetBackingStream(URN& target);
 
     void Clear();
 
-    aff4_off_t Size() override;
+    aff4_off_t Size() const override;
 
     using AFF4Stream::Write;
 };

--- a/aff4/aff4_registry.h
+++ b/aff4/aff4_registry.h
@@ -25,13 +25,13 @@ class ClassFactory {
     std::unordered_map<
     std::string, std::function<T* (DataStore*, const URN*)> > factoryFunctionRegistry;
 
-    std::unique_ptr<T> CreateInstance(char* name, DataStore* resolver,
-                                      const URN* urn = nullptr) {
+    std::unique_ptr<T> CreateInstance(const char* name, DataStore* resolver,
+                                      const URN* urn = nullptr) const {
         return CreateInstance(std::string(name), resolver, urn);
     }
 
     std::unique_ptr<T> CreateInstance(std::string name, DataStore* data,
-                                      const URN* urn = nullptr) {
+                                      const URN* urn = nullptr) const {
         T* instance = nullptr;
 
         // find name in the registry and call factory method.

--- a/aff4/aff4_symstream.cc
+++ b/aff4/aff4_symstream.cc
@@ -41,7 +41,7 @@ namespace aff4 {
         } else {
             // fill with pattern
             const size_t pSz = pattern.size();
-            char* data = const_cast<char*>(result.data());
+            char* data = &result[0];
             size_t toRead = length;
             while (toRead > 0) {
                 int pOffset = readptr % pSz;

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -206,7 +206,7 @@ class AFF4ScopedPtr {
     DataStore* resolver_;
 
   public:
-    AFF4ScopedPtr(): ptr_(0), resolver_(nullptr) {}
+    AFF4ScopedPtr(): ptr_(nullptr), resolver_(nullptr) {}
     explicit AFF4ScopedPtr(AFF4ObjectType* p, DataStore* resolver):
     ptr_(p), resolver_(resolver) {
         if (resolver == nullptr) abort();
@@ -225,7 +225,7 @@ class AFF4ScopedPtr {
     }
 
     AFF4ObjectType* operator->() const {
-        if(ptr_ == nullptr) abort();
+        if (ptr_ == nullptr) abort();
         return ptr_;
     }
 
@@ -251,9 +251,15 @@ class AFF4ScopedPtr {
         ptr_ = p;
     }
 
-    AFF4ScopedPtr(AFF4ScopedPtr&& other) {
+    AFF4ScopedPtr(AFF4ScopedPtr&& other):
+        ptr_(other.release()), resolver_(other.resolver_) {}
+
+    AFF4ScopedPtr& operator=(AFF4ScopedPtr&& other) {
+      if (this != &other) {
         ptr_ = other.release();
         resolver_ = other.resolver_;
+      }
+      return *this;
     }
 
     AFF4ScopedPtr(const AFF4ScopedPtr& other) = delete;

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -229,7 +229,7 @@ class AFF4ScopedPtr {
         return ptr_;
     }
 
-    bool operator!(void)  {
+    bool operator!(void) const {
         return ptr_ ? false : true;
     }
 
@@ -686,8 +686,8 @@ class MemoryDataStore: public DataStore {
 
     AFF4Status LoadFromTurtle(AFF4Stream& output) override;
 
-    AFF4Status Clear() override;
-    AFF4Status Flush() override;
+    virtual AFF4Status Clear() override;
+    virtual AFF4Status Flush() override;
 };
 
 } // namespace aff4

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -692,8 +692,8 @@ class MemoryDataStore: public DataStore {
 
     AFF4Status LoadFromTurtle(AFF4Stream& output) override;
 
-    virtual AFF4Status Clear() override;
-    virtual AFF4Status Flush() override;
+    AFF4Status Clear() override;
+    AFF4Status Flush() override;
 };
 
 } // namespace aff4

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -70,12 +70,12 @@ class LogSink: public spdlog::sinks::sink {
 public:
     virtual ~LogSink() {}
 
-    virtual void log(const spdlog::details::log_msg& msg) override {
+    void log(const spdlog::details::log_msg& msg) override {
         // trampoline to our thread-local log handler
         get_log_handler().log(msg);
     }
 
-    virtual void flush() override {}
+    void flush() override {}
 };
 
 struct Holder {

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -167,7 +167,7 @@ off_t AFF4Stream::Tell() {
     return readptr;
 }
 
-off_t AFF4Stream::Size() {
+off_t AFF4Stream::Size() const {
     return size;
 }
 
@@ -341,7 +341,7 @@ std::string StringIO::Read(size_t length) {
     return result;
 }
 
-off_t StringIO::Size() {
+off_t StringIO::Size() const {
     return buffer.size();
 }
 
@@ -393,7 +393,7 @@ std::string GetLastErrorMessage() {
 
 extern "C" {
     const char* AFF4_version() {
-        static std::string version = std::string("libaff4 version ") + AFF4_VERSION;
+        static const std::string version = std::string("libaff4 version ") + AFF4_VERSION;
         return version.c_str();
     }
 }

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -696,7 +696,7 @@ std::string ZipFileSegment::Read(size_t length) {
     return result;
 }
 
-aff4_off_t ZipFileSegment::Size() {
+aff4_off_t ZipFileSegment::Size() const {
     if (_backing_store_start_offset < 0) {
         return StringIO::Size();
     }
@@ -846,7 +846,7 @@ AFF4Status ZipFileSegment::Flush() {
 
         zip_info->crc32_cs = crc32(
             zip_info->crc32_cs,
-            reinterpret_cast<Bytef*>(const_cast<char*>(buffer.data())),
+            reinterpret_cast<const Bytef*>(buffer.data()),
             buffer.size());
 
         if (compression_method == AFF4_IMAGE_COMPRESSION_ENUM_DEFLATE) {
@@ -1064,7 +1064,7 @@ AFF4Status ZipFile::StreamAddMember(URN member_urn, AFF4Stream& stream,
             int output_bytes = AFF4_BUFF_SIZE - strm.avail_out;
             zip_info->crc32_cs = crc32(
                 zip_info->crc32_cs,
-                reinterpret_cast<Bytef*>(const_cast<char*>(buffer.data())),
+                reinterpret_cast<const Bytef*>(buffer.data()),
                 buffer.size() - strm.avail_in);
 
             if (backing_store->Write(c_buffer.get(), output_bytes) < 0) {
@@ -1119,7 +1119,7 @@ AFF4Status ZipFile::StreamAddMember(URN member_urn, AFF4Stream& stream,
             zip_info->file_size += buffer.size();
             zip_info->crc32_cs = crc32(
                 zip_info->crc32_cs,
-                reinterpret_cast<Bytef*>(const_cast<char*>(buffer.data())),
+                reinterpret_cast<const Bytef*>(buffer.data()),
                 buffer.size());
 
             RETURN_IF_ERROR(backing_store->Write(buffer.data(), buffer.size()));

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -181,7 +181,7 @@ class ZipFileSegment: public StringIO {
     std::string Read(size_t length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
-    aff4_off_t Size() override;
+    virtual aff4_off_t Size() const override;
 
     AFF4Status WriteStream(
         AFF4Stream* source, ProgressContext* progress = nullptr) override;

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -181,7 +181,7 @@ class ZipFileSegment: public StringIO {
     std::string Read(size_t length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
-    virtual aff4_off_t Size() const override;
+    aff4_off_t Size() const override;
 
     AFF4Status WriteStream(
         AFF4Stream* source, ProgressContext* progress = nullptr) override;

--- a/tools/pmem/linux_pmem.h
+++ b/tools/pmem/linux_pmem.h
@@ -28,7 +28,7 @@ struct ram_range {
 
 class LinuxPmemImager: public PmemImager {
  protected:
-    virtual std::string GetName() {
+    virtual std::string GetName() const {
         return "The LinuxPmem memory imager.  Copyright 2014 Google Inc.";
   }
 

--- a/tools/pmem/pmem.h
+++ b/tools/pmem/pmem.h
@@ -31,11 +31,11 @@ class PmemImager: public BasicImager {
     std::vector<std::string> pagefiles;
     std::string volume_type;
 
-    virtual std::string GetName() {
+    virtual std::string GetName() const {
         return "The Pmem physical memory imager. Copyright 2014 Google Inc.";
     }
 
-    virtual std::string GetVersion() {
+    virtual std::string GetVersion() const {
         return PMEM_VERSION;
     }
 


### PR DESCRIPTION
  * Made some variables which never change const.
  * Made some member functions which are non-modifying const.
  * Pass some arguments as references instead of pointers.
  * Removed some unnecessary const_casts.
  * Don't bother naming an object which will immediately be returned.