### PR TITLE
Handle invalid size detection on macOS block devices

### DIFF
--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -383,11 +383,12 @@ AFF4Status BasicImager::process_input() {
                 resolver.Set(image_urn, AFF4_STREAM_ORIGINAL_FILENAME,
                              new XSDString(input));
             }
+
             // For very small streams, it is more efficient to just store them without
             // compression. Also if the user did not ask for compression, there is no
             // advantage in storing a Bevy based image, just store it in one piece.
             if (compression == AFF4_IMAGE_COMPRESSION_ENUM_STORED ||
-                    input_stream->Size() < 10 * 1024 * 1024) {
+                    (input_stream->Size() > 0 && input_stream->Size() < 10 * 1024 * 1024) ) {
                 AFF4ScopedPtr<AFF4Stream> image_stream = volume->CreateMember(
                             image_urn);
 


### PR DESCRIPTION
On macOS (and possibly other operating systems) trying to get the size of a block device via the file handle always reports zero bytes.  This causes the imager's logic to assume the file is small enough to avoid chunk-based compression, and leads to the entire image being decompressed in memory when trying to open the image for reading.

This proposed simple solution is to check for a reported 0 byte size and in that case always use a bevy based image.  Most block devices that are being imaged are going to be larger than the 10 MiB size anyway, and actual zero byte files won't encounter any overhead when reading anyway.