### PR TITLE
Make the map standards compliant by adding stream size

### DIFF
--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -89,6 +89,17 @@ AFF4Status AFF4Map::LoadFromURN() {
         }
     }
 
+    // If the map has a STREAM_SIZE property we set the size based on that,
+    // otherwise we fall back to the last range in the map.
+    XSDInteger value;
+    if (resolver->Get(urn, AFF4_STREAM_SIZE, value) == STATUS_OK) {
+        size = value.value;
+    } else {
+        if (!map.empty()) {
+            size = (--map.end())->second.map_end();
+        }
+    }
+
     return STATUS_OK;
 }
 
@@ -196,14 +207,12 @@ std::string AFF4Map::Read(size_t length) {
 }
 
 aff4_off_t AFF4Map::Size() {
-    // The size of the stream is the end of the last range.
-    auto it = map.end();
-    if (it == map.begin()) {
-        return 0;
-    }
+    return size;
+}
 
-    it--;
-    return it->second.map_end();
+void AFF4Map::SetSize(aff4_off_t size) {
+    this->size = size;
+    MarkDirty();
 }
 
 static std::vector<Range> _MergeRanges(std::vector<Range>& ranges) {
@@ -521,6 +530,11 @@ AFF4Status AFF4Map::AddRange(aff4_off_t map_offset, aff4_off_t target_offset,
         }
     }
 
+    const auto last_byte = (--map.end())->second.map_end();
+    if (size < last_byte) {
+        size = last_byte;
+    }
+
     MarkDirty();
 
     return STATUS_OK;
@@ -566,6 +580,9 @@ AFF4Status AFF4Map::Flush() {
         }
 
         resolver->Close(idx_stream);
+
+        // Add the stream size property to the map
+        resolver->Set(urn, AFF4_STREAM_SIZE, new XSDInteger(size));
     }
 
     return AFF4Stream::Flush();

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -58,6 +58,8 @@ class AFF4Map: public AFF4Stream {
     // The URN that will be used as the target of the next Write() operation.
     URN last_target;
 
+    aff4_off_t size{}; // Logical size of the map stream
+
   public:
     // The target list.
     std::vector<URN> targets;
@@ -101,6 +103,7 @@ class AFF4Map: public AFF4Stream {
     void Clear();
 
     aff4_off_t Size() override;
+    void SetSize(aff4_off_t size);
 
     using AFF4Stream::Write;
 };


### PR DESCRIPTION
As discussed on the AFF4 mailing list, the standard requires that map streams have a stream size property.  This PR accomplishes that without adding the unnecessary overhead that Michael seemed to be concerned about.  Disconnecting the map stream size from the ranges also allows you to have sparse maps with sparse data at the end.