### PR TITLE
Reimplement AFF4Stream::Read() in terms of AFF4Stream::ReadBuffer()

### DIFF
--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -188,9 +188,13 @@ AFF4Status FileBackedObject::LoadFromURN() {
 }
 
 std::string FileBackedObject::Read(size_t length) {
+    if (length == 0) {
+        return "";
+    }
+
     std::string result(length, '\0');
     if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-      return "";
+        return "";
     }
     result.resize(length);
     return result;

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -467,11 +467,6 @@ AFF4Status AFF4BuiltInStreams::LoadFromURN() {
     return IO_ERROR;
 }
 
-std::string AFF4BuiltInStreams::Read(size_t length) {
-    UNUSED(length);
-    return "";
-}
-
 AFF4Status AFF4BuiltInStreams::Write(const char* data, size_t length) {
     int res = write(fd, data, length);
     if (res >= 0) {

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -89,19 +89,6 @@ AFF4Status _CreateIntermediateDirectories(DataStore *resolver, std::string dir_n
     return _CreateIntermediateDirectories(resolver, split(dir_name, PATH_SEP));
 }
 
-std::string FileBackedObject::Read(size_t length) {
-    if (length == 0) {
-        return "";
-    }
-
-    std::string result(length, '\0');
-    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-        return "";
-    }
-    result.resize(length);
-    return result;
-}
-
 // Windows files are read through the CreateFile() API so that devices can be
 // read.
 #if defined(_WIN32)

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -49,8 +49,8 @@ class FileBackedObject: public AFF4Stream {
     explicit FileBackedObject(DataStore* resolver): AFF4Stream(resolver), fd(0){}
     virtual ~FileBackedObject();
 
-    std::string Read(size_t length) override;
-    AFF4Status ReadBuffer(char* data, size_t *length) override;
+    virtual std::string Read(size_t length) override;
+    virtual AFF4Status ReadBuffer(char* data, size_t *length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     /**

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -90,11 +90,11 @@ class AFF4ConstantStream: public AFF4Stream {
         return STATUS_OK;
     }
 
-    virtual std::string Read(size_t length) override {
+    std::string Read(size_t length) override {
         return std::string(length, constant);
     }
 
-    virtual AFF4Status ReadBuffer(char* data, size_t* length) override {
+    AFF4Status ReadBuffer(char* data, size_t* length) override {
         std::memset(data, constant, *length);
         return STATUS_OK;
     }

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -49,8 +49,7 @@ class FileBackedObject: public AFF4Stream {
     explicit FileBackedObject(DataStore* resolver): AFF4Stream(resolver), fd(0){}
     virtual ~FileBackedObject();
 
-    virtual std::string Read(size_t length) override;
-    virtual AFF4Status ReadBuffer(char* data, size_t *length) override;
+    AFF4Status ReadBuffer(char* data, size_t *length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     /**

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -88,8 +88,13 @@ class AFF4ConstantStream: public AFF4Stream {
         return STATUS_OK;
     }
 
-    std::string Read(size_t length) override {
+    virtual std::string Read(size_t length) override {
         return std::string(length, constant);
+    }
+
+    virtual AFF4Status ReadBuffer(char* data, size_t* length) override {
+        std::memset(data, constant, *length);
+        return STATUS_OK;
     }
 };
 

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -74,7 +74,7 @@ class FileBackedObject: public AFF4Stream {
 
 
 /*
-  A stream which just returns the same char over.
+  A stream which just returns the same char over and over.
  */
 class AFF4ConstantStream: public AFF4Stream {
     char constant = 0;

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -23,6 +23,8 @@ specific language governing permissions and limitations under the License.
 #include "aff4/aff4_utils.h"
 #include "aff4/rdf.h"
 
+#include <cstring>
+
 namespace aff4 {
 
 /*

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -96,7 +96,6 @@ class AFF4ConstantStream: public AFF4Stream {
 class AFF4BuiltInStreams : public AFF4Stream {
  public:
     explicit AFF4BuiltInStreams(DataStore *resolver): AFF4Stream(resolver) {}
-    std::string Read(size_t length) override;
     AFF4Status Write(const char* data, size_t length) override;
     AFF4Status Seek(aff4_off_t offset, int whence) override;
     AFF4Status LoadFromURN() override;

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -942,7 +942,8 @@ AFF4Status AFF4StdImage::ReadBuffer(char* data, size_t* length) {
     auto delegate_stream = resolver->AFF4FactoryOpen<AFF4Stream>(delegate);
     if (!delegate_stream) {
         resolver->logger->error(
-            "Unable to open aff4:dataStream {} for Image {}", delegate, urn
+            "Unable to open aff4:dataStream {} for Image {}",
+            delegate, urn
         );
         *length = 0;
         return STATUS_OK; // FIXME?

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -24,9 +24,9 @@ specific language governing permissions and limitations under the License.
 namespace aff4 {
 
 
-AFF4Status CompressZlib_(const std::string &input, std::string* output) {
+AFF4Status CompressZlib_(const std::string &input, std::string& output) {
     uLongf c_length = compressBound(input.size()) + 1;
-    output->resize(c_length);
+    output.resize(c_length);
 
     if (compress2(reinterpret_cast<Bytef*>(&(*output)[0]),
                   &c_length,
@@ -35,18 +35,18 @@ AFF4Status CompressZlib_(const std::string &input, std::string* output) {
         return MEMORY_ERROR;
     }
 
-    output->resize(c_length);
+    output.resize(c_length);
 
     return STATUS_OK;
 }
 
-AFF4Status DeCompressZlib_(const std::string &input, std::string* output) {
-    uLongf buffer_size = output->size();
+AFF4Status DeCompressZlib_(const std::string &input, std::string& output) {
+    uLongf buffer_size = output.size();
 
     if (uncompress(reinterpret_cast<Bytef*>(&(*output)[0]),
                    &buffer_size,
                    (const Bytef*)input.data(), input.size()) == Z_OK) {
-        output->resize(buffer_size);
+        output.resize(buffer_size);
         return STATUS_OK;
     }
 
@@ -54,15 +54,15 @@ AFF4Status DeCompressZlib_(const std::string &input, std::string* output) {
 }
 
 
-AFF4Status CompressSnappy_(const std::string &input, std::string* output) {
-    snappy::Compress(input.data(), input.size(), output);
+AFF4Status CompressSnappy_(const std::string &input, std::string& output) {
+    snappy::Compress(input.data(), input.size(), &output);
 
     return STATUS_OK;
 }
 
 
-AFF4Status DeCompressSnappy_(const std::string &input, std::string* output) {
-    if (!snappy::Uncompress(input.data(), input.size(), output)) {
+AFF4Status DeCompressSnappy_(const std::string &input, std::string& output) {
+    if (!snappy::Uncompress(input.data(), input.size(), &output)) {
         return GENERIC_ERROR;
     }
 
@@ -176,12 +176,12 @@ private:
 
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB: {
-            RETURN_IF_ERROR(CompressZlib_(data, &c_data));
+            RETURN_IF_ERROR(CompressZlib_(data, c_data));
         }
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY: {
-            RETURN_IF_ERROR(CompressSnappy_(data, &c_data));
+            RETURN_IF_ERROR(CompressSnappy_(data, c_data));
         }
             break;
 
@@ -675,11 +675,11 @@ AFF4Status AFF4Image::ReadChunkFromBevy(
     } else {
         switch (compression) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB:
-            res = DeCompressZlib_(cbuffer, &buffer);
+            res = DeCompressZlib_(cbuffer, buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY:
-            res = DeCompressSnappy_(cbuffer, &buffer);
+            res = DeCompressSnappy_(cbuffer, buffer);
             break;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_LZ4:
@@ -748,7 +748,7 @@ int AFF4Image::_ReadPartial(unsigned int chunk_id, int chunks_to_read,
 
         if (isAFF4Legacy) {
             // Massage the bevvy data format from the old into the new.
-            bevy_index_data = _FixupBevyData(&bevy_index_data);
+            bevy_index_data = _FixupBevyData(bevy_index_data);
             index_size = bevy_index->Size() / sizeof(uint32_t);
         }
 

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -820,21 +820,6 @@ AFF4Status AFF4Image::ReadBuffer(char* data, size_t* length) {
     return STATUS_OK;
 }
 
-// FIXME: move to base class
-std::string AFF4Image::Read(size_t length) {
-    if (length == 0) {
-        return "";
-    }
-
-    std::string result(length, '\0');
-    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-        return "";
-    }
-
-    result.resize(length);
-    return result;
-}
-
 AFF4Status AFF4Image::_write_metadata() {
     resolver->Set(urn, AFF4_TYPE, new URN(AFF4_IMAGESTREAM_TYPE),
                   /* replace = */ false);
@@ -951,20 +936,6 @@ AFF4Status AFF4StdImage::ReadBuffer(char* data, size_t* length) {
 
     delegate_stream->Seek(readptr, SEEK_SET);
     return delegate_stream->ReadBuffer(data, length);
-}
-
-std::string AFF4StdImage::Read(size_t length) {
-    if (length == 0) {
-        return "";
-    }
-
-    std::string result(length, '\0');
-    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-        return "";
-    }
-
-    result.resize(length);
-    return result;
 }
 
 // AFF4 Standard

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -177,6 +177,8 @@ class AFF4Image: public AFF4Stream {
      */
     std::string Read(size_t length) override;
 
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
+
     AFF4Status Flush() override;
 
     using AFF4Stream::Write;

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -168,15 +168,6 @@ class AFF4Image: public AFF4Stream {
 
     AFF4Status Write(const char* data, size_t length) override;
 
-    /**
-     * Read data from the current read pointer.
-     *
-     * @param length: How much data to read.
-     *
-     * @return A string containing the data to read.
-     */
-    std::string Read(size_t length) override;
-
     AFF4Status ReadBuffer(char* data, size_t* length) override;
 
     AFF4Status Flush() override;
@@ -207,7 +198,6 @@ class AFF4StdImage : public AFF4Stream {
     AFF4Status LoadFromURN() override;
 
     AFF4Status ReadBuffer(char* data, size_t* length) override;
-    std::string Read(size_t length) override;
 
  protected:
     URN delegate;

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -62,10 +62,10 @@ namespace aff4 {
  */
 
 // Compression methods we support.
-AFF4Status CompressZlib_(const char* data, size_t length, std::string& output);
-AFF4Status DeCompressZlib_(const char* data, size_t length, std::string& output);
-AFF4Status CompressSnappy_(const char* data, size_t length, std::string& output);
-AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string& output);
+AFF4Status CompressZlib_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressZlib_(const char* data, size_t length, std::string* output);
+AFF4Status CompressSnappy_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string* output);
 
 
 // This is the type written to the map stream in this exact binary layout.
@@ -83,7 +83,7 @@ class AFF4Image: public AFF4Stream {
     AFF4Status FlushBevy();
 
     // Convert the legecy formatted bevvy data into the new format.
-    std::string _FixupBevyData(std::string& data);
+    std::string _FixupBevyData(std::string* data);
 
     int _ReadPartial(
         unsigned int chunk_id, int chunks_to_read, std::string& result);

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -62,10 +62,10 @@ namespace aff4 {
  */
 
 // Compression methods we support.
-AFF4Status CompressZlib_(const char* data, size_t length, std::string* output);
-AFF4Status DeCompressZlib_(const char* data, size_t length, std::string* output);
-AFF4Status CompressSnappy_(const char* data, size_t length, std::string* output);
-AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string* output);
+AFF4Status CompressZlib_(const char* data, size_t length, std::string& output);
+AFF4Status DeCompressZlib_(const char* data, size_t length, std::string& output);
+AFF4Status CompressSnappy_(const char* data, size_t length, std::string& output);
+AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string& output);
 
 
 // This is the type written to the map stream in this exact binary layout.
@@ -83,7 +83,7 @@ class AFF4Image: public AFF4Stream {
     AFF4Status FlushBevy();
 
     // Convert the legecy formatted bevvy data into the new format.
-    std::string _FixupBevyData(std::string* data);
+    std::string _FixupBevyData(std::string& data);
 
     int _ReadPartial(
         unsigned int chunk_id, int chunks_to_read, std::string& result);

--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -206,6 +206,7 @@ class AFF4StdImage : public AFF4Stream {
 
     AFF4Status LoadFromURN() override;
 
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
     std::string Read(size_t length) override;
 
  protected:

--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -206,7 +206,8 @@ class StringIO: public AFF4Stream {
         return std::unique_ptr<StringIO>(new StringIO());
     }
 
-    std::string Read(size_t length) override;
+    virtual std::string Read(size_t length) override;
+    virtual AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status Truncate() override;

--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -206,8 +206,8 @@ class StringIO: public AFF4Stream {
         return std::unique_ptr<StringIO>(new StringIO());
     }
 
-    virtual std::string Read(size_t length) override;
-    virtual AFF4Status ReadBuffer(char* data, size_t* length) override;
+    std::string Read(size_t length) override;
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status Truncate() override;

--- a/aff4/aff4_io.h
+++ b/aff4/aff4_io.h
@@ -160,7 +160,7 @@ class AFF4Stream: public AFF4Object {
     virtual AFF4Status Seek(aff4_off_t offset, int whence);
     virtual std::string Read(size_t length);
 
-    virtual AFF4Status ReadBuffer(char *data, size_t *length);
+    virtual AFF4Status ReadBuffer(char* data, size_t* length);
 
     virtual AFF4Status Write(const char* data, size_t length);
     virtual aff4_off_t Tell();

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -111,21 +111,6 @@ AFF4Status AFF4Map::LoadFromURN() {
     return STATUS_OK;
 }
 
-// FIXME: move to base class
-std::string AFF4Map::Read(size_t length) {
-    if (length == 0) {
-        return "";
-    }
-
-    std::string result(length, '\0');
-    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-        return "";
-    }
-
-    result.resize(length);
-    return result;
-}
-
 AFF4Status AFF4Map::ReadBuffer(char* data, size_t* length) {
     if (*length > AFF4_MAX_READ_LEN) {
         *length = 0;

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -77,7 +77,6 @@ class AFF4Map: public AFF4Stream {
 
     AFF4Status LoadFromURN() override;
 
-    std::string Read(size_t length) override;
     AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 

--- a/aff4/aff4_map.h
+++ b/aff4/aff4_map.h
@@ -78,6 +78,7 @@ class AFF4Map: public AFF4Stream {
     AFF4Status LoadFromURN() override;
 
     std::string Read(size_t length) override;
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     AFF4Status WriteStream(

--- a/aff4/aff4_symstream.cc
+++ b/aff4/aff4_symstream.cc
@@ -57,21 +57,6 @@ namespace aff4 {
         return STATUS_OK;
     }
 
-    // FIXME: move to base class
-    std::string AFF4SymbolicStream::Read(size_t length) {
-        if (length == 0) {
-            return "";
-        }
-
-        std::string result(length, '\0');
-        if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-            return "";
-        }
-
-        result.resize(length);
-        return result;
-    }
-
     void AFF4SymbolicStream::Return() {
         // Don't return to the resolver as we are a permanent entity.
         //resolver->Return(this);

--- a/aff4/aff4_symstream.cc
+++ b/aff4/aff4_symstream.cc
@@ -26,14 +26,12 @@ namespace aff4 {
         // NOP
     }
 
-    std::string AFF4SymbolicStream::Read(size_t length) {
-        std::string result;
-        result.resize(length);
+    AFF4Status AFF4SymbolicStream::ReadBuffer(char* data, size_t* length) {
         if (pattern.empty()) {
             // fill with symbol
-            std::memset((void*) result.data(), symbol, length);
-            readptr += length;
-            // cycle around to zero if we go passed the logical end of
+            std::memset(data, symbol, *length);
+            readptr += *length;
+            // cycle around to zero if we go past the logical end of
             // the stream.
             if (readptr < 0) {
                 readptr = 0;
@@ -41,22 +39,36 @@ namespace aff4 {
         } else {
             // fill with pattern
             const size_t pSz = pattern.size();
-            char* data = &result[0];
-            size_t toRead = length;
+            size_t toRead = *length;
             while (toRead > 0) {
                 int pOffset = readptr % pSz;
                 *data = pattern[pOffset];
-                data++;
-                toRead--;
+                ++data;
+                --toRead;
 
-                readptr++;
-                // cycle around to zero if we go passed the logical
+                ++readptr;
+                // cycle around to zero if we go past the logical
                 // end of the stream.
                 if (readptr < 0) {
                     readptr = 0;
                 }
             }
         }
+        return STATUS_OK;
+    }
+
+    // FIXME: move to base class
+    std::string AFF4SymbolicStream::Read(size_t length) {
+        if (length == 0) {
+            return "";
+        }
+
+        std::string result(length, '\0');
+        if (ReadBuffer(&result[0], &length) != STATUS_OK) {
+            return "";
+        }
+
+        result.resize(length);
         return result;
     }
 

--- a/aff4/aff4_symstream.h
+++ b/aff4/aff4_symstream.h
@@ -24,7 +24,6 @@ class AFF4SymbolicStream: public AFF4Stream {
 
     virtual ~AFF4SymbolicStream();
 
-    std::string Read(size_t length) override;
     AFF4Status ReadBuffer(char* data, size_t* length) override;
 
     // Override AFF4Object::Return();

--- a/aff4/aff4_symstream.h
+++ b/aff4/aff4_symstream.h
@@ -24,7 +24,8 @@ class AFF4SymbolicStream: public AFF4Stream {
 
     virtual ~AFF4SymbolicStream();
 
-    std::string Read(size_t length);
+    std::string Read(size_t length) override;
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
 
     // Override AFF4Object::Return();
     void Return();

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -692,8 +692,8 @@ class MemoryDataStore: public DataStore {
 
     AFF4Status LoadFromTurtle(AFF4Stream& output) override;
 
-    AFF4Status Clear() override;
-    AFF4Status Flush() override;
+    virtual AFF4Status Clear() override;
+    virtual AFF4Status Flush() override;
 };
 
 } // namespace aff4

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -692,8 +692,8 @@ class MemoryDataStore: public DataStore {
 
     AFF4Status LoadFromTurtle(AFF4Stream& output) override;
 
-    virtual AFF4Status Clear() override;
-    virtual AFF4Status Flush() override;
+    AFF4Status Clear() override;
+    AFF4Status Flush() override;
 };
 
 } // namespace aff4

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -223,6 +223,7 @@ ssize_t AFF4_read(int handle, uint64_t offset, void* buffer, size_t length, AFF4
             stream->ReadBuffer(static_cast<char*>(buffer), &length) != aff4::STATUS_OK)
         {
             errno = EIO;
+            return -1;
         }
     }
     else {

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -92,7 +92,7 @@ uint64_t AFF4_object_size(int handle, AFF4_Message** msg);
  * @param msg A pointer to log messages.
  * @return The number of bytes placed into the buffer.
  */
-int AFF4_read(int handle, uint64_t offset, void* buffer, int length, AFF4_Message** msg);
+ssize_t AFF4_read(int handle, uint64_t offset, void* buffer, size_t length, AFF4_Message** msg);
 
 /**
  * Close the given handle.

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -127,17 +127,21 @@ AFF4Status AFF4Stream::Seek(off_t offset, int whence) {
 }
 
 std::string AFF4Stream::Read(size_t length) {
-    UNUSED(length);
-    return "";
+    if (length == 0) {
+        return "";
+    }
+
+    std::string result(length, '\0');
+    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
+        return "";
+    }
+    result.resize(length);
+    return result;
 }
 
 AFF4Status AFF4Stream::ReadBuffer(char* data, size_t *length) {
-    auto result = Read(*length);
-
-    *length = result.size();
-
-    memcpy(data, result.c_str(), *length);
-
+    UNUSED(data);
+    *length = 0;
     return STATUS_OK;
 }
 

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -337,8 +337,14 @@ AFF4Status StringIO::Write(const char* data, size_t length) {
 std::string StringIO::Read(size_t length) {
     std::string result = buffer.substr(readptr, length);
     readptr += result.size();
-
     return result;
+}
+
+AFF4Status StringIO::ReadBuffer(char* data, size_t* length) {
+    *length = std::min(*length, buffer.size() - readptr);
+    std::memcpy(data, buffer.data() + readptr, *length);
+    readptr += *length;
+    return STATUS_OK;
 }
 
 off_t StringIO::Size() const {

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -160,11 +160,9 @@ AFF4Status AFF4Stream::Write(const char* data, size_t length) {
 }
 
 int AFF4Stream::ReadIntoBuffer(void* buffer, size_t length) {
-    std::string result = Read(length);
-
-    memcpy(buffer, result.data(), result.size());
-
-    return result.size();
+    // FIXME: errors?
+    ReadBuffer(reinterpret_cast<char*>(buffer), &length);
+    return length;
 }
 
 off_t AFF4Stream::Tell() {

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -675,19 +675,9 @@ AFF4Status ZipFileSegment::LoadFromZipFile(
     return STATUS_OK;
 }
 
-// FIXME: move to base class
 std::string ZipFileSegment::Read(size_t length) {
-    if (length == 0) {
-        return "";
-    }
-
-    std::string result(length, '\0');
-    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
-        return "";
-    }
-
-    result.resize(length);
-    return result;
+    // We want the default implementation, no the one from StringIO::Read
+    return AFF4Stream::Read(length);
 }
 
 AFF4Status ZipFileSegment::ReadBuffer(char* data, size_t* length) {

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -675,23 +675,40 @@ AFF4Status ZipFileSegment::LoadFromZipFile(
     return STATUS_OK;
 }
 
+// FIXME: move to base class
 std::string ZipFileSegment::Read(size_t length) {
+    if (length == 0) {
+        return "";
+    }
+
+    std::string result(length, '\0');
+    if (ReadBuffer(&result[0], &length) != STATUS_OK) {
+        return "";
+    }
+
+    result.resize(length);
+    return result;
+}
+
+AFF4Status ZipFileSegment::ReadBuffer(char* data, size_t* length) {
     if (_backing_store_start_offset < 0) {
-        return StringIO::Read(length);
+        return StringIO::ReadBuffer(data, length);
     }
 
     AFF4ScopedPtr<AFF4Stream> backing_store = resolver->AFF4FactoryOpen<AFF4Stream>(_backing_store_urn);
     if (!backing_store || (size_t)readptr > _backing_store_length) {
-        return "";
+        *length = 0;
+        return STATUS_OK; // FIXME??
     }
 
     aff4_off_t offset = _backing_store_start_offset + readptr;
-    size_t to_read = std::min((aff4_off_t) length, (aff4_off_t) _backing_store_length - readptr);
+    *length = std::min((aff4_off_t) *length, (aff4_off_t) _backing_store_length
+ - readptr);
 
     backing_store->Seek(offset, SEEK_SET);
 
-    std::string result = backing_store->Read(to_read);
-    readptr += result.size();
+    const AFF4Status result = backing_store->ReadBuffer(data, length);
+    readptr += *length;
 
     return result;
 }

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -676,7 +676,7 @@ AFF4Status ZipFileSegment::LoadFromZipFile(
 }
 
 std::string ZipFileSegment::Read(size_t length) {
-    // We want the default implementation, no the one from StringIO::Read
+    // We want the default implementation, not the one from StringIO::Read
     return AFF4Stream::Read(length);
 }
 

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -178,8 +178,8 @@ class ZipFileSegment: public StringIO {
     AFF4Status Flush() override;
     AFF4Status Truncate() override;
 
-    virtual std::string Read(size_t length) override;
-    virtual AFF4Status ReadBuffer(char* data, size_t* length) override;
+    std::string Read(size_t length) override;
+    AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     aff4_off_t Size() const override;

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -178,7 +178,8 @@ class ZipFileSegment: public StringIO {
     AFF4Status Flush() override;
     AFF4Status Truncate() override;
 
-    std::string Read(size_t length) override;
+    virtual std::string Read(size_t length) override;
+    virtual AFF4Status ReadBuffer(char* data, size_t* length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
     aff4_off_t Size() const override;

--- a/tests/aff4_capi.cc
+++ b/tests/aff4_capi.cc
@@ -50,7 +50,7 @@ TEST_F(AFF4CAPI, Sample1URN) {
 
     char* buffer = (char*) malloc(33);
     memset(buffer, 0, 33);
-    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
+    ssize_t read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
@@ -72,7 +72,7 @@ TEST_F(AFF4CAPI, Sample2URN) {
     memset(buffer, 0, 33);
 
     // Start
-    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
+    ssize_t read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
@@ -100,7 +100,7 @@ TEST_F(AFF4CAPI, Sample3URN) {
     memset(buffer, 0, 33);
 
     // Start...
-    int read = AFF4_read(handle, 0, buffer, 32, nullptr);
+    ssize_t read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 

--- a/tests/aff4_capi.cc
+++ b/tests/aff4_capi.cc
@@ -13,9 +13,9 @@
   specific language governing permissions and limitations under the License.
 */
 #include <gtest/gtest.h>
-#include "aff4/libaff4-c.h"
-#include <unistd.h>
 #include <glog/logging.h>
+
+#include "aff4/libaff4-c.h"
 
 namespace aff4 {
 
@@ -48,13 +48,12 @@ TEST_F(AFF4CAPI, Sample1URN) {
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    char* buffer = (char*) malloc(33);
+    char buffer[33];
     memset(buffer, 0, 33);
     ssize_t read = AFF4_read(handle, 0, buffer, 32, nullptr);
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x33\xC0\x8E\xD0\xBC\x00\x7C\x8E\xC0\x8E\xD8\xBE\x00\x7C\xBF\x00\x06\xB9\x00\x02\xFC\xF3\xA4\x50\x68\x1C\x06\xCB\xFB\xB9\x04\x00", buffer);
 
-    free(buffer);
     AFF4_close(handle, nullptr);
 }
 
@@ -68,7 +67,7 @@ TEST_F(AFF4CAPI, Sample2URN) {
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    char* buffer = (char*) malloc(33);
+    char buffer[33];
     memset(buffer, 0, 33);
 
     // Start
@@ -82,7 +81,6 @@ TEST_F(AFF4CAPI, Sample2URN) {
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x4D\xD9\x8B\x8C\xE2\x39\x44\x58\x6B\xA2\xA8\xDB\x04\x1C\x6D\x36\x81\x41\x36\x8B\x90\xA7\x16\xC2\x5E\x9A\x0C\xA6\xE6\xD9\x0B\x7E", buffer);
 
-    free(buffer);
     AFF4_close(handle, nullptr);
 }
 
@@ -96,7 +94,7 @@ TEST_F(AFF4CAPI, Sample3URN) {
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
 
-    char* buffer = (char*) malloc(33);
+    char buffer[33];
     memset(buffer, 0, 33);
 
     // Start...
@@ -110,7 +108,6 @@ TEST_F(AFF4CAPI, Sample3URN) {
     ASSERT_EQ(32, read);
     ASSERT_STREQ("\x55\x4E\x52\x45\x41\x44\x41\x42\x4C\x45\x44\x41\x54\x41\x55\x4E\x52\x45\x41\x44\x41\x42\x4C\x45\x44\x41\x54\x41\x55\x4E\x52\x45", buffer);
 
-    free(buffer);
     AFF4_close(handle, nullptr);
 }
 

--- a/tools/pmem/win_pmem.cc
+++ b/tools/pmem/win_pmem.cc
@@ -243,16 +243,13 @@ class _PipedReaderStream: public AFF4Stream {
       stdout_rd(stdout_rd)
   {}
 
-  std::string Read(size_t length) {
-      std::string buffer(length, 0);
-      DWORD bytes_read = buffer.size();
-
-      if (!ReadFile(stdout_rd, &buffer[0], bytes_read, &bytes_read, NULL)) {
-          return "";
+  AFF4Status ReadBuffer(char* data, size_t* length) override {
+      if (!ReadFile(stdout_rd, data, *length, length, NULL)) {
+          return STATUS_OK; // FIXME?
       }
 
-      readptr += bytes_read;
-      return buffer;
+      readptr += *length;
+      return STATUS_OK;
   }
 
   virtual ~_PipedReaderStream() {


### PR DESCRIPTION
This PR reimplements `AFF4Stream::Read()` in terms of `AFF4Stream::ReadBuffer()` and makes `AFF4_read()` use `AFF4Stream::ReadBuffer()` in order to eliminate unnecessary copying of data when a destination buffer already exists.

Fixes Issue #30.