### PR TITLE
More cleanup

### DIFF
--- a/aff4/aff4_base.h
+++ b/aff4/aff4_base.h
@@ -111,7 +111,7 @@ class AFF4Object {
     }
 
     // Return this object to the resolver.
-    void Return();
+    virtual void Return();
 
     // By defining a virtual destructor this allows the destructor of derived
     // objects to be called when deleting a pointer to a base object.

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -440,11 +440,10 @@ class AFF4FileRegistrer {
         });
     }
 
-    AFF4Object* GetObject(DataStore* resolver, const URN* urn) {
+    AFF4Object* GetObject(DataStore* resolver, const URN* urn) const {
         if (AFF4Directory::IsDirectory(*urn)) {
             return new AFF4Directory(resolver, *urn);
         }
-        XSDString mode;
 
         return new FileBackedObject(resolver);
     }

--- a/aff4/aff4_registry.h
+++ b/aff4/aff4_registry.h
@@ -22,9 +22,6 @@ class URN;
 template<class T>
 class ClassFactory {
   public:
-    std::unordered_map<
-    std::string, std::function<T* (DataStore*, const URN*)> > factoryFunctionRegistry;
-
     std::unique_ptr<T> CreateInstance(const char* name, DataStore* resolver,
                                       const URN* urn = nullptr) const {
         return CreateInstance(std::string(name), resolver, urn);
@@ -35,7 +32,7 @@ class ClassFactory {
         T* instance = nullptr;
 
         // find name in the registry and call factory method.
-        auto it = factoryFunctionRegistry.find(name);
+        const auto it = factoryFunctionRegistry.find(name);
         if (it != factoryFunctionRegistry.end()) {
             instance = it->second(data, urn);
         }
@@ -45,10 +42,17 @@ class ClassFactory {
 
     void RegisterFactoryFunction(
         std::string name, std::function<
-        T*(DataStore*, const URN*)> classFactoryFunction) {
+        T*(DataStore*, const URN*)> classFactoryFunction)
+    {
         // register the class factory function
         factoryFunctionRegistry[name] = classFactoryFunction;
     }
+
+  private:
+    std::unordered_map<
+      std::string,
+      std::function<T* (DataStore*, const URN*)>
+    > factoryFunctionRegistry;
 };
 
 #endif  // SRC_AFF4_REGISTRY_H_

--- a/aff4/aff4_symstream.h
+++ b/aff4/aff4_symstream.h
@@ -26,8 +26,7 @@ class AFF4SymbolicStream: public AFF4Stream {
 
     std::string Read(size_t length);
 
-    // Override AFF4Object::Return();
-    void Return();
+    void Return() override;
 
  protected:
     uint8_t symbol;

--- a/aff4/data_store.cc
+++ b/aff4/data_store.cc
@@ -403,9 +403,8 @@ AFF4Status MemoryDataStore::DumpToTurtle(AFF4Stream& output_stream, URN base, bo
             }
 
             // Load all attributes.
-            const std::vector<std::shared_ptr<RDFValue>> attr = attr_it.second;
-            for (auto at_it = attr.begin(); at_it != attr.end(); at_it++) {
-                const RDFValue* value = (*at_it).get();
+            for (const auto& a: attr_it.second) {
+                const RDFValue* value = a.get();
 
                 // Skip this URN if it is in the suppressed_rdftypes set.
                 if (ShouldSuppress(

--- a/aff4/data_store.cc
+++ b/aff4/data_store.cc
@@ -836,7 +836,7 @@ AFF4Object* AFF4ObjectCache::Get(const URN urn) {
 }
 
 void AFF4ObjectCache::Return(AFF4Object* object) {
-    std::string key = object->urn.SerializeToString();
+    const std::string key = object->urn.SerializeToString();
     auto it = in_use.find(key);
 
     // This should never happen - Only objects obtained from Get() should be
@@ -869,7 +869,7 @@ void AFF4ObjectCache::Return(AFF4Object* object) {
 }
 
 AFF4Status AFF4ObjectCache::Remove(AFF4Object* object) {
-    std::string key = object->urn.SerializeToString();
+    const std::string key = object->urn.SerializeToString();
     AFF4Status res;
 
     auto it = lru_map.find(key);

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -591,7 +591,7 @@ class DataStore {
      * @param object
      */
     void Return(AFF4Object* object) {
-        std::string urn = object->urn.SerializeToString();
+        const std::string urn = object->urn.SerializeToString();
         // Don't return symbolics.
         auto it = SymbolicStreams.find(urn);
         if (it != SymbolicStreams.end()) {

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -558,9 +558,9 @@ class DataStore {
         // Cache the object for next time.
         T* result = dynamic_cast<T*>(obj.get());
 
-        if(result == nullptr){
-                // bad type cast.
-                return AFF4ScopedPtr<T>();
+        if (result == nullptr){
+            // bad type cast.
+            return AFF4ScopedPtr<T>();
         }
 
         // Store the object in the cache but place it immediate in the in_use list.

--- a/aff4/lexicon.cc
+++ b/aff4/lexicon.cc
@@ -33,7 +33,7 @@ std::unordered_map<std::string, Schema> Schema::cache;
 
 Schema Schema::GetSchema(std::string object_type) {
     // If we did not add any schema yet, do so now.
-    if(cache.size() == 0) {
+    if (cache.size() == 0) {
         // Define all the Schema and attributes.
         Schema AFF4_OBJECT_SCHEMA("object");
         AFF4_OBJECT_SCHEMA.AddAttribute(

--- a/aff4/lexicon.h
+++ b/aff4/lexicon.h
@@ -110,6 +110,7 @@ class Schema {
     Schema() {}
 
     Schema(std::string object_type): object_type(object_type) {}
+
     void AddAttribute(std::string alias, Attribute attribute) {
         attributes[alias] = attribute;
     }

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -76,6 +76,8 @@ AFF4Object::AFF4Object(DataStore* resolver): resolver(resolver) {
     UuidToString(&newId, &buffer);
 
     urn.Set(AFF4_PREFIX + std::string(reinterpret_cast<char*>(buffer)));
+
+    RpcStringFree(&buffer);
 }
 
 #endif


### PR DESCRIPTION
This PR adds more `const`s, fixes a memory leak, marks a `virtual` function which was missed, and stops copying a `std::vector` just to iterate it.