### PR TITLE
C API returns real handles

### DIFF
--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -70,7 +70,7 @@ void AFF4_free_messages(AFF4_Message* msg);
  */
 void AFF4_set_verbosity(unsigned int level);
 
-struct AFF4_Handle;
+typedef struct AFF4_Handle AFF4_Handle;
 
 /**
  * Open the given filename, and access the first aff4:Image in the container.

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -21,7 +21,7 @@
 /*
  * This is the C interface into libaff4.
  *
- * Note: This API is NOT MT-SAFE.
+ * Note: Individual handles are NOT MT-SAFE.
  */
 
 #ifdef __cplusplus
@@ -70,18 +70,20 @@ void AFF4_free_messages(AFF4_Message* msg);
  */
 void AFF4_set_verbosity(unsigned int level);
 
+struct AFF4_Handle;
+
 /**
  * Open the given filename, and access the first aff4:Image in the container.
  * @param filename The filename to open.
  * @param msg A pointer to log messages.
- * @return Object handle, or -1 on error. See errno
+ * @return Object handle, or NULL on error. See errno
  */
-int AFF4_open(const char* filename, AFF4_Message** msg);
+AFF4_Handle* AFF4_open(const char* filename, AFF4_Message** msg);
 
 /**
  * Get the size of the AFF4 Object that was opened.
  */
-uint64_t AFF4_object_size(int handle, AFF4_Message** msg);
+uint64_t AFF4_object_size(AFF4_Handle* handle, AFF4_Message** msg);
 
 /**
  * Read a block from the given handle.
@@ -92,7 +94,7 @@ uint64_t AFF4_object_size(int handle, AFF4_Message** msg);
  * @param msg A pointer to log messages.
  * @return The number of bytes placed into the buffer.
  */
-ssize_t AFF4_read(int handle, uint64_t offset, void* buffer, size_t length, AFF4_Message** msg);
+ssize_t AFF4_read(AFF4_Handle* handle, uint64_t offset, void* buffer, size_t length, AFF4_Message** msg);
 
 /**
  * Close the given handle.
@@ -100,7 +102,7 @@ ssize_t AFF4_read(int handle, uint64_t offset, void* buffer, size_t length, AFF4
  * @param msg A pointer to log messages.
  * @return 0, or -1 on error.
  */
-int AFF4_close(int handle, AFF4_Message** msg);
+int AFF4_close(AFF4_Handle* handle, AFF4_Message** msg);
 
 #ifdef __cplusplus
 }

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -557,10 +557,10 @@ void aff4_init() {
 
 
 std::shared_ptr<spdlog::logger> get_logger() {
-    auto logger = spdlog::get("aff4");
+    auto logger = spdlog::get(aff4::LOGGER);
 
     if (!logger) {
-        return spdlog::stderr_color_mt("aff4");
+        return spdlog::stderr_color_mt(aff4::LOGGER);
     }
 
     return logger;

--- a/aff4/libaff4.h
+++ b/aff4/libaff4.h
@@ -68,6 +68,8 @@ extern "C" {
 
 std::string aff4_sprintf(std::string fmt, ...);
 
+const char LOGGER[] = "aff4";
+
 } // namespace aff4
 
 

--- a/tests/aff4_capi.cc
+++ b/tests/aff4_capi.cc
@@ -42,8 +42,8 @@ TEST_F(AFF4CAPI, Sample1URN) {
 
     AFF4_init();
 
-    int handle = AFF4_open(filename.c_str(), nullptr);
-    ASSERT_NE(-1, handle);
+    AFF4_Handle* handle = AFF4_open(filename.c_str(), nullptr);
+    ASSERT_TRUE(handle);
 
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
@@ -61,8 +61,8 @@ TEST_F(AFF4CAPI, Sample2URN) {
     std::string filename = reference_images + "AFF4Std/Base-Allocated.aff4";
     AFF4_init();
 
-    int handle = AFF4_open(filename.c_str(), nullptr);
-    ASSERT_NE(-1, handle);
+    AFF4_Handle* handle = AFF4_open(filename.c_str(), nullptr);
+    ASSERT_TRUE(handle);
 
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);
@@ -88,8 +88,8 @@ TEST_F(AFF4CAPI, Sample3URN) {
     std::string filename = reference_images + "AFF4Std/Base-Linear-ReadError.aff4";
     AFF4_init();
 
-    int handle = AFF4_open(filename.c_str(), nullptr);
-    ASSERT_NE(-1, handle);
+    AFF4_Handle* handle = AFF4_open(filename.c_str(), nullptr);
+    ASSERT_TRUE(handle);
 
     uint64_t size = AFF4_object_size(handle, nullptr);
     ASSERT_EQ(268435456, size);


### PR DESCRIPTION
Two changes:

* Use an opaque pointer to a handle struct instead of an int handle
* Define a variable for the name of the aff4 logger rather than repeat the string everywhere.

The purpose of the handle change is to eliminate the static handle map, which makes the library as a whole thread-unsafe. With this change, individual handles remain thread-unsafe (which is normal for handles), but distinct handles may now be used on different threads simultaneously.

This is the last change to the C API I have queued up. Once this is in, I intend to update the patch for adding AFF4 support to Sleuthkit correspondingly and press for that to get merged.