### PR TITLE
Fixed exception for URNs without paths

### DIFF
--- a/aff4/rdf.cc
+++ b/aff4/rdf.cc
@@ -141,7 +141,13 @@ std::string URN::Path() const {
     }
 
     if (Scheme() == "aff4") {
-        return value.substr(strlen(AFF4_PREFIX) + Domain().size() + 1);
+        // Calculate offset of any trailing path
+        const auto offset = strlen(AFF4_PREFIX) + Domain().size() + 1;
+
+        // Some valid URNs don't have paths
+        if (value.size() > offset) {
+            return value.substr(offset);
+        }
     }
 
     return "";


### PR DESCRIPTION
This PR fixes an exception when calling URN::Path when a valid URN does not have a path.  I've come across this when trying to export streams that are in the classic form of just aff4://UUID.