### PR TITLE
AFF4StdImage should advance its own readptr when reading from delegate

### DIFF
--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -935,7 +935,12 @@ AFF4Status AFF4StdImage::ReadBuffer(char* data, size_t* length) {
     }
 
     delegate_stream->Seek(readptr, SEEK_SET);
-    return delegate_stream->ReadBuffer(data, length);
+
+    auto data = delegate_stream->Read(length);
+
+    Seek(data.size(), SEEK_CUR);
+
+    return data;
 }
 
 // AFF4 Standard


### PR DESCRIPTION
Currently trying to export a AFF4StdImage stream fails because the stream's internal read pointer was not advancing.  This resolves that problem.