### PR TITLE
Autoload of striped images

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,7 @@
 BUILDING
 ========
 
+* Read the README that applies to your OS
 * Build the required prerequisite libraries.
 
 * Build and install the AFF4 library:
@@ -16,30 +17,3 @@ TESTING
   $ make check
   
   
-BUILDING OS X
-================
-
-Install the following via macports
-* zlib
-* raptor2
-* google-glog
-* pcrexx
-* tclap (missing *.pc file - place in /opt/local/lib/pkgconfig/)
-
-Install the following manually as they aren't in macports
-* snappy 
-* uuid 
-
-$ cd ~/git
-$ git clone ssh://bastion/srv/git/aff4.git
-$ cd aff4
-$ git submodule update --init third_party/gtest
-   Ignore the error about tree reference.
-$ cd third_party/gtest
-$ git reset --hard
-$ cd ../..
-$ ./autogen.sh
-$ ./configure CC=clang CXX=clang++ CXXFLAGS="-std=c++11 -stdlib=libc++ -O2 -g0 -I/opt/local/include" LDFLAGS="-stdlib=libc++ -L/opt/local/lib"
-$ make
-
-For the manual installations, need to ensure they are installed in /opt/local. ("./configure --prefix=/opt/local")

--- a/README.linux
+++ b/README.linux
@@ -82,7 +82,7 @@ make -j4 install
 cd ..
 
 apt-get source libspdlog-dev
-cd spdlog-0.11.0/
+cd spdlog-0.17.0/
 cmake -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX . && make all install
 cd ..
 

--- a/README.macos
+++ b/README.macos
@@ -1,0 +1,42 @@
+brew install 
+brew install 
+brew install snappy lz4 raptor pkgconfig tclap uriparser spdlog
+
+BUILDING OS X
+================
+
+Install the following via macports
+* zlib
+* raptor2
+* google-glog
+* pcrexx
+* tclap (missing *.pc file - place in /opt/local/lib/pkgconfig/)
+* yaml-cpp
+* snappy 
+
+Install the following manually as they aren't in macports
+
+* uuid 
+
+Then do the following
+
+cd ~/git
+git clone https://github.com/gabime/spdlog.git
+cd spdlog
+git checkout v0.17.0
+cmake  . && make all install 
+cd ..
+git clone https://github.com/Velocidex/c-aff4.git
+cd c-aff4
+git submodule update --init third_party/gtest
+
+   Ignore the error about tree reference.
+
+cd third_party/gtest
+git reset --hard
+cd ../..
+./autogen.sh
+./configure CC=clang CXX=clang++ CXXFLAGS="-std=c++11 -stdlib=libc++ -O2 -g0 -I/opt/local/include" LDFLAGS="-stdlib=libc++ -L/opt/local/lib"
+make
+
+For the manual installations, need to ensure they are installed in /opt/local. ("./configure --prefix=/opt/local")

--- a/README.macos
+++ b/README.macos
@@ -1,22 +1,9 @@
-brew install 
-brew install 
-brew install snappy lz4 raptor pkgconfig tclap uriparser spdlog
-
-BUILDING OS X
+BUILDING MacOS
 ================
 
-Install the following via macports
-* zlib
-* raptor2
-* google-glog
-* pcrexx
-* tclap (missing *.pc file - place in /opt/local/lib/pkgconfig/)
-* yaml-cpp
-* snappy 
+Install the following via brew
 
-Install the following manually as they aren't in macports
-
-* uuid 
+brew install snappy lz4 raptor pkgconfig tclap uriparser spdlog
 
 Then do the following
 

--- a/aff4/aff4_base.h
+++ b/aff4/aff4_base.h
@@ -52,6 +52,32 @@ specific language governing permissions and limitations under the License.
 // Windows defines this macro which interfers with glog's version.
 #undef ERROR
 
+#ifdef __APPLE__
+
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#define pread64 pread
+#define O_LARGEFILE 0
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif
+
 #include "aff4/lexicon.h"
 #include "aff4/aff4_errors.h"
 #include "aff4/rdf.h"

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -263,9 +263,8 @@ FileBackedObject::~FileBackedObject() {
      std::string mode,
      AFF4Flusher<FileBackedObject> &result
  ) {
-     auto new_object = AFF4Flusher<FileBackedObject>(new FileBackedObject(resolver));
+     auto new_object = AFF4Flusher<FileBackedObject>(new FileBackedObject(resolver, filename));
      new_object->urn = URN::NewURNFromFilename(filename, false);
-
      std::vector<std::string> directory_components = split(filename, PATH_SEP);
      directory_components.pop_back();
 

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -46,7 +46,7 @@ class FileBackedObject: public AFF4Stream {
     // The filename for this object.
     std::string filename;
 
-    explicit FileBackedObject(DataStore* resolver): AFF4Stream(resolver), fd(0){}
+    explicit FileBackedObject(DataStore* resolver, std::string filename): AFF4Stream(resolver), filename(filename), fd(0){}
     virtual ~FileBackedObject();
 
     AFF4Status ReadBuffer(char* data, size_t *length) override;

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -353,6 +353,7 @@ AFF4Status AFF4Image::OpenAFF4Image(
             resolver->logger->error(
                 "ImageStream {} does not specify a size. "
                 "Is this part of a split image set?", new_obj->urn);
+            return NOT_FOUND;
         }
 
     } else {

--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -252,6 +252,7 @@ AFF4Status BasicImager::handle_aff4_volumes() {
 
                 volume_objs.AddVolume(
                     std::move(AFF4Flusher<AFF4Volume>(volume.release())));
+                volume_objs.AddSearchPath(volume_to_load);
             }
         }
     }

--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -643,6 +643,13 @@ AFF4Status BasicImager::handle_compression() {
 // We only allow a wild card in the last component.
 std::vector<std::string> BasicImager::GlobFilename(std::string glob) const {
     std::vector<std::string> result;
+
+    // Devices do not glob.
+    if (glob.substr(0,2) == "\\\\") {
+        result.push_back(glob);
+        return result;
+    }
+
     WIN32_FIND_DATA ffd;
     unsigned int found = glob.find_last_of("/\\");
     std::string path = "";

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -566,7 +566,7 @@ AFF4Status AFF4Map::WriteStream(AFF4Stream* source, ProgressContext* progress) {
     RETURN_IF_ERROR(last_target->WriteStream(source, progress));
 
     // Add a single range to cover the bulk of the image.
-    AddRange(0, last_target->Size(), last_target->Size(), last_target);
+    AddRange(0, 0, last_target->Size(), last_target);
 
     return STATUS_OK;
 }

--- a/aff4/aff4_utils.h
+++ b/aff4/aff4_utils.h
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations under the License.
-*/
+ */
 
 #ifndef SRC_AFF4_UTILS_H_
 #define SRC_AFF4_UTILS_H_
@@ -22,19 +22,22 @@ specific language governing permissions and limitations under the License.
 #include <string>
 #include <sstream>
 
+#include <codecvt>
+#include <locale>
+
 #include "spdlog/spdlog.h"
 
 namespace aff4 {
 
 #define UNUSED(x) (void)x
 
-std::string aff4_sprintf(std::string fmt, ...);
+    std::string aff4_sprintf(std::string fmt, ...);
 
-std::string GetLastErrorMessage();
+    std::string GetLastErrorMessage();
 
-std::vector<std::string> split(const std::string& s, char delim);
+    std::vector<std::string> split(const std::string& s, char delim);
 
-std::shared_ptr<spdlog::logger> get_logger();
+    std::shared_ptr<spdlog::logger> get_logger();
 
 #define RETURN_IF_ERROR(expr)                   \
     do {                                        \
@@ -45,19 +48,62 @@ std::shared_ptr<spdlog::logger> get_logger();
         };                                      \
     } while (0);
 
-// A portable version of fnmatch.
-int fnmatch(const char *pattern, const char *string);
+    // A portable version of fnmatch.
+    int fnmatch(const char *pattern, const char *string);
 
-inline bool hasEnding(std::string const &fullString, std::string const &ending) {
-    if (fullString.length() >= ending.length()) {
-        return (0 == fullString.compare(
+    inline bool hasEnding(std::string const &fullString, std::string const &ending) {
+        if (fullString.length() >= ending.length()) {
+            return (0 == fullString.compare(
                     fullString.length() - ending.length(),
                     ending.length(), ending));
-    } else {
-         return false;
+        } else {
+            return false;
+        }
     }
-}
 
+    inline bool IsAFF4Container(std::string filename) noexcept {
+        // Cheap nasty not really unicode transformation to lower case.
+        std::transform(filename.begin(), filename.end(), filename.begin(), ::tolower);
+        return hasEnding(filename, ".af4") || hasEnding(filename, ".aff4");
+    }
+
+    /**
+     * Does the file entity exist, and is a regular file.
+     * @param name The filename to check
+     * @return TRUE if the file entity exists and is a regular file.
+     */
+    inline bool IsFile(const std::string& name) {
+#ifndef _WIN32
+        /*
+         * POSIX based systems.
+         */
+        struct stat buffer;
+        if (::stat(name.c_str(), &buffer) == 0) {
+            return S_ISREG(buffer.st_mode);
+        }
+        return false;
+#else 
+        /*
+         * Windows based systems
+         */
+        std::wstring filename = s2ws(name);
+        DWORD dwAttrib = GetFileAttributes(filename.c_str());
+        return (dwAttrib != INVALID_FILE_ATTRIBUTES && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY));
+
+#endif
+    }
+
+    inline std::wstring s2ws(const std::string& str) {
+        using convert_typeX = std::codecvt_utf8<wchar_t>;
+        std::wstring_convert<convert_typeX, wchar_t> converterX;
+        return converterX.from_bytes(str);
+    }
+
+    inline std::string ws2s(const std::wstring& wstr) {
+        using convert_typeX = std::codecvt_utf8<wchar_t>;
+        std::wstring_convert<convert_typeX, wchar_t> converterX;
+        return converterX.to_bytes(wstr);
+    }
 
 } // namespace aff4
 

--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -153,6 +153,7 @@ AFF4_Handle* AFF4_open(const char* filename, AFF4_Message** msg) {
     };
 
     h->volumes.AddVolume(std::move(zip));
+    h->volumes.AddSearchPath(filename);
 
     // Attempt AFF4 Standard, and if not, fallback to AFF4 Evimetry Legacy format.
     images = h->resolver.Query(aff4::AFF4_TYPE, &type);

--- a/aff4/volume_group.cc
+++ b/aff4/volume_group.cc
@@ -1,123 +1,304 @@
+#include <set>
+
 #include "aff4/volume_group.h"
+
+#include "aff4/aff4_errors.h"
+#include "aff4/data_store.h"
 #include "aff4/aff4_image.h"
 #include "aff4/aff4_map.h"
+#include "aff4/aff4_file.h"
+#include "aff4/aff4_directory.h"
 #include "aff4/zip.h"
 #include "aff4/aff4_symstream.h"
+#include <stdlib.h>
+#include <limits.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <dirent.h>
+#endif
 
 namespace aff4 {
 
-
-
-
-void VolumeGroup::AddVolume(AFF4Flusher<AFF4Volume> &&volume) {
-    volume_objs.insert(std::make_pair(volume->urn, std::move(volume)));
-}
-
-// Construct the appropriate stream and return it.
-AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &result) {
-    // Get all the type attrbutes of the URN.
-    std::vector<std::shared_ptr<RDFValue>> types;
-    if (STATUS_OK == resolver->Get(stream_urn, AFF4_TYPE, types)) {
-        for (auto &type : types) {
-            std::string type_str(type->SerializeToString());
-
-            if (type_str == AFF4_IMAGESTREAM_TYPE ||
-                type_str == AFF4_LEGACY_IMAGESTREAM_TYPE) {
-                AFF4Flusher<AFF4Image> image_stream;
-                RETURN_IF_ERROR(
-                    AFF4Image::OpenAFF4Image(
-                        resolver, stream_urn, this, image_stream));
-
-                result.reset(image_stream.release());
-
-                resolver->logger->debug("Openning {} as type {}",
-                                        stream_urn, type_str);
-                return STATUS_OK;
+    void VolumeGroup::AddVolume(AFF4Flusher<AFF4Volume> &&volume) {
+        /*
+         *  If the volume is a ZipFile, add the filename to the search path.
+         */
+        AFF4Volume* vol = volume.get();
+        if (ZipFile * v = dynamic_cast<ZipFile*> (vol)) {
+            AFF4Stream* stream = v->backing_stream.get();
+            if (FileBackedObject * f = dynamic_cast<FileBackedObject*> (stream)) {
+                std::string filename = f->filename;
+                AddSearchPath(filename);
             }
+        }
+        volume_objs.insert(std::make_pair(volume->urn, std::move(volume)));
+    }
 
-            // The AFF4 Standard specifies an "AFF4 Image" as an abstract
-            // container for image related properties. It is not actually a
-            // concrete stream but it refers to a storage stream using its
-            // aff4:dataStream property.
-
-            // Note that to create such a stream, you can simply create a
-            // regular stream with NewAFF4Image or NewAFF4Map and then set
-            // the aff4:dataStream of a new object to a concerete Map or
-            // ImageStream.
-            if (type_str == AFF4_IMAGE_TYPE ||
-                type_str == AFF4_DISK_IMAGE_TYPE ||
-                type_str == AFF4_VOLUME_IMAGE_TYPE ||
-                type_str == AFF4_MEMORY_IMAGE_TYPE ||
-                type_str == AFF4_CONTIGUOUS_IMAGE_TYPE ||
-                type_str == AFF4_DISCONTIGUOUS_IMAGE_TYPE) {
-                URN delegate;
-
-                if (STATUS_OK == resolver->Get(stream_urn, AFF4_DATASTREAM, delegate)) {
-                    // TODO: This can get recursive. Protect against abuse.
-                    return GetStream(delegate, result);
-                }
-            }
-
-            if (type_str == AFF4_MAP_TYPE) {
-                AFF4Flusher<AFF4Map> map_stream;
-                RETURN_IF_ERROR(
-                    AFF4Map::OpenAFF4Map(
-                        resolver, stream_urn, this, map_stream));
-
-                result.reset(map_stream.release());
-                resolver->logger->debug("Openning {} as type {}",
-                                        stream_urn, type_str);
-
-                return STATUS_OK;
-            }
-
-            // Zip segments are stored directly in each volume. We use
-            // the resolver to figure out which volume has each
-            // segment.
-            if (type_str == AFF4_ZIP_SEGMENT_TYPE ||
-                type_str == AFF4_FILE_TYPE) {
-                URN owner;
-                RETURN_IF_ERROR(resolver->Get(stream_urn, AFF4_STORED, owner));
-
-                resolver->logger->debug("Openning {} as type {}", stream_urn, type_str);
-                auto it = volume_objs.find(owner);
-                if (it != volume_objs.end()) {
-                    return (it->second->OpenMemberStream(stream_urn, result));
-                }
-            }
+    void VolumeGroup::AddSearchPath(std::string path) {
+        // Convert to absolute.
+#ifdef _WIN32
+        char resolved[_PATH_MAX + 1];
+        memset(&resolved, 0, _PATH_MAX + 1);
+        if (_fullpath((char*)&resolved, path.c_str(), _PATH_MAX) != NULL) {
+            path = std::string(resolved);
+        }
+#else 
+        char resolved[PATH_MAX + 1];
+        memset(&resolved, 0, PATH_MAX + 1);
+        if (realpath(path.c_str(), (char*)&resolved) != NULL) {
+            path = std::string(resolved);
+        }
+#endif
+        if (AFF4Directory::IsDirectory(path, /* must_exist= */ true)) {
+            searchPaths.insert(path);
+        } else {
+            // get the parent path.
+            path = path.substr(0, path.find_last_of("/\\"));
+            searchPaths.insert(path);
         }
     }
 
-    // Handle symbolic streams now.
-    if (stream_urn == AFF4_IMAGESTREAM_ZERO) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0));
-        return STATUS_OK;
-    }
-    if (stream_urn == AFF4_IMAGESTREAM_FF) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0xff));
-        return STATUS_OK;
-    }
-    if (stream_urn == AFF4_IMAGESTREAM_UNKNOWN) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNKNOWN"));
-        return STATUS_OK;
-    }
-    if (stream_urn == AFF4_IMAGESTREAM_UNREADABLE) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNREADABLEDATA"));
-        return STATUS_OK;
+    void VolumeGroup::RemoveSearchPath(std::string path) {
+        searchPaths.erase(path);
     }
 
-    for (int i = 0; i < 256; i++) {
-        std::string urn = aff4_sprintf(
-            "%s%02X", AFF4_IMAGESTREAM_SYMBOLIC_PREFIX, i);
+    // Construct the appropriate stream and return it.
 
-        if (stream_urn == urn) {
-            result.reset(new AFF4SymbolicStream(resolver, stream_urn, i));
+    AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &result) {
+        // Get all the type attrbutes of the URN.
+        std::vector<std::shared_ptr < RDFValue>> types;
+        if (STATUS_OK == resolver->Get(stream_urn, AFF4_TYPE, types)) {
+            for (auto &type : types) {
+                std::string type_str(type->SerializeToString());
+
+                if (type_str == AFF4_IMAGESTREAM_TYPE ||
+                        type_str == AFF4_LEGACY_IMAGESTREAM_TYPE) {
+                    AFF4Flusher<AFF4Image> image_stream;
+                    RETURN_IF_ERROR(
+                            AFF4Image::OpenAFF4Image(
+                            resolver, stream_urn, this, image_stream));
+
+                    result.reset(image_stream.release());
+
+                    resolver->logger->debug("Openning {} as type {}",
+                            stream_urn, type_str);
+                    return STATUS_OK;
+                }
+
+                // The AFF4 Standard specifies an "AFF4 Image" as an abstract
+                // container for image related properties. It is not actually a
+                // concrete stream but it refers to a storage stream using its
+                // aff4:dataStream property.
+
+                // Note that to create such a stream, you can simply create a
+                // regular stream with NewAFF4Image or NewAFF4Map and then set
+                // the aff4:dataStream of a new object to a concerete Map or
+                // ImageStream.
+                if (type_str == AFF4_IMAGE_TYPE ||
+                        type_str == AFF4_DISK_IMAGE_TYPE ||
+                        type_str == AFF4_VOLUME_IMAGE_TYPE ||
+                        type_str == AFF4_MEMORY_IMAGE_TYPE ||
+                        type_str == AFF4_CONTIGUOUS_IMAGE_TYPE ||
+                        type_str == AFF4_DISCONTIGUOUS_IMAGE_TYPE) {
+                    URN delegate;
+
+                    if (STATUS_OK == resolver->Get(stream_urn, AFF4_DATASTREAM, delegate)) {
+                        // TODO: This can get recursive. Protect against abuse.
+                        return GetStream(delegate, result);
+                    }
+                }
+
+                if (type_str == AFF4_MAP_TYPE) {
+                    AFF4Flusher<AFF4Map> map_stream;
+                    RETURN_IF_ERROR(
+                            AFF4Map::OpenAFF4Map(
+                            resolver, stream_urn, this, map_stream));
+
+                    result.reset(map_stream.release());
+                    resolver->logger->debug("Openning {} as type {}",
+                            stream_urn, type_str);
+
+                    return STATUS_OK;
+                }
+
+                // Zip segments are stored directly in each volume. We use
+                // the resolver to figure out which volume has each
+                // segment.
+                if (type_str == AFF4_ZIP_SEGMENT_TYPE ||
+                        type_str == AFF4_FILE_TYPE) {
+                    URN owner;
+                    RETURN_IF_ERROR(resolver->Get(stream_urn, AFF4_STORED, owner));
+
+                    resolver->logger->debug("Openning {} as type {}", stream_urn, type_str);
+                    auto it = volume_objs.find(owner);
+                    if (it != volume_objs.end()) {
+                        return (it->second->OpenMemberStream(stream_urn, result));
+                    }
+                }
+            }
+        }
+
+        // Handle symbolic streams now.
+        if (stream_urn == AFF4_IMAGESTREAM_ZERO) {
+            result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0));
             return STATUS_OK;
         }
+        if (stream_urn == AFF4_IMAGESTREAM_FF) {
+            result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0xff));
+            return STATUS_OK;
+        }
+        if (stream_urn == AFF4_IMAGESTREAM_UNKNOWN) {
+            result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNKNOWN"));
+            return STATUS_OK;
+        }
+        if (stream_urn == AFF4_IMAGESTREAM_UNREADABLE) {
+            result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNREADABLEDATA"));
+            return STATUS_OK;
+        }
+
+        for (int i = 0; i < 256; i++) {
+            std::string urn = aff4_sprintf(
+                    "%s%02X", AFF4_IMAGESTREAM_SYMBOLIC_PREFIX, i);
+
+            if (stream_urn == urn) {
+                result.reset(new AFF4SymbolicStream(resolver, stream_urn, i));
+                return STATUS_OK;
+            }
+        }
+
+        return NOT_FOUND;
     }
 
-    return NOT_FOUND;
+    AFF4Status VolumeGroup::LocateAndAdd(URN& urn) {
+        if (volume_objs.find(urn) != volume_objs.end()) {
+            // Already loaded....
+            return STATUS_OK;
+        }
+
+        // Check known volume URNs.
+        if (foundVolumes.find(urn) != foundVolumes.end()) {
+
+            std::string volume_to_load = foundVolumes.find(urn)->second;
+            // load and return;
+            AFF4Flusher<FileBackedObject> backing_stream;
+            RETURN_IF_ERROR(NewFileBackedObject(
+                    resolver, volume_to_load,
+                    "read", backing_stream));
+
+            AFF4Flusher<ZipFile> volume;
+            RETURN_IF_ERROR(ZipFile::OpenZipFile(
+                    resolver,
+                    std::move(AFF4Flusher<AFF4Stream>(
+                    backing_stream.release())),
+                    volume));
+
+            AddVolume(std::move(AFF4Flusher<AFF4Volume>(volume.release())));
+            return STATUS_OK;
+        }
+
+        // Search for container.
+        resolver->logger->info("Searching for container {}", urn);
+        for (std::string path : searchPaths) {
+            /* 
+             * Look for all AFF4 in this path, and check it's URN.
+             */
+            ScanForAFF4Volumes(path);
+        }
+        // Check known volume URNs.
+        if (foundVolumes.find(urn) != foundVolumes.end()) {
+
+            std::string volume_to_load = foundVolumes.find(urn)->second;
+            
+            resolver->logger->info("Searching for container {} = {}", urn, volume_to_load);
+            
+            // load and return;
+            AFF4Flusher<FileBackedObject> backing_stream;
+            RETURN_IF_ERROR(NewFileBackedObject(
+                    resolver, volume_to_load,
+                    "read", backing_stream));
+
+            AFF4Flusher<ZipFile> volume;
+            RETURN_IF_ERROR(ZipFile::OpenZipFile(
+                    resolver,
+                    std::move(AFF4Flusher<AFF4Stream>(
+                    backing_stream.release())),
+                    volume));
+
+            AddVolume(std::move(AFF4Flusher<AFF4Volume>(volume.release())));
+            return STATUS_OK;
+        }
+
+        return NOT_FOUND;
+    }
+
+    bool VolumeGroup::FoundVolumesContains(const std::string& filename) {
+	for (auto it = foundVolumes.begin(); it != foundVolumes.end(); it++) {
+		if (it->second.compare(filename) == 0) {
+			return true;
+		}
+	}
+	return false;
 }
 
+    void VolumeGroup::ScanForAFF4Volumes(const std::string& path) {
+        // It is expected that the map is LOCKED prior to this call.
+        if (path.empty()) {
+            return;
+        }
+        resolver->logger->info("Scanning path {}", path);
+#ifdef _WIN32
+        /*
+         * Windows based systems
+         */
+        std::wstring wpath = s2ws(path);
 
-} // namespace aff4
+        std::wstring pattern(wpath);
+        pattern.append(L"\\*");
+
+        WIN32_FIND_DATAW data;
+        HANDLE hFind;
+        if ((hFind = FindFirstFile(pattern.c_str(), &data)) != INVALID_HANDLE_VALUE) {
+            do {
+                std::wstring filename(data.cFileName);
+                if (filename.compare(L".") && filename.compare(L"..")) {
+                    std::string absoluteFilename = path + "\\" + ws2s(filename);
+                    if ((IsFile(absoluteFilename)) && (IsAFF4Container(ws2s(filename)))) {
+                        if (!FoundVolumesContains(absoluteFilename)) {
+                            // We don't have this file
+                            std::string resID = aff4::ZipFile::GetResourceID(absoluteFilename, resolver->logger);
+                            if (!resID.empty()) {
+                                foundVolumes[resID] = absoluteFilename;
+                            }
+                        }
+                    }
+                }
+                while (FindNextFile(hFind, &data) != 0);
+                FindClose(hFind);
+            }
+#else
+        /*
+         * POSIX based systems.
+         */
+        DIR* dirp = ::opendir(path.c_str());
+        struct dirent * dp;
+        while ((dp = readdir(dirp)) != NULL) {
+            std::string filename(dp->d_name);
+            if (filename.compare(".") && filename.compare("..")) {
+                std::string absoluteFilename = path + "/" + filename;
+                if ((IsFile(absoluteFilename)) && (IsAFF4Container(filename))) {
+                    if (!FoundVolumesContains(absoluteFilename)) {
+                        // We don't have this file
+                        std::string resID = aff4::ZipFile::GetResourceID(absoluteFilename, resolver->logger);
+                        if (!resID.empty()) {
+                            foundVolumes[resID] = absoluteFilename;
+                        }
+                    }
+                }
+            }
+        }
+        closedir(dirp);
+#endif
+        }
+
+    } // namespace aff4

--- a/aff4/volume_group.h
+++ b/aff4/volume_group.h
@@ -2,17 +2,22 @@
 #define     AFF4_VOLUME_GROUP_H_
 
 #include <unordered_map>
+#include <set>
+
 #include "aff4/aff4_io.h"
 #include "aff4/data_store.h"
-
-
 
 namespace aff4 {
 
  class VolumeGroup {
  protected:
-     std::unordered_map<URN, AFF4Flusher<AFF4Volume>> volume_objs;
-     DataStore *resolver;
+    std::unordered_map<URN, AFF4Flusher<AFF4Volume>> volume_objs;
+    DataStore *resolver;
+
+    std::set<std::string> searchPaths;
+    std::unordered_map<URN, std::string> foundVolumes;
+
+    bool FoundVolumesContains(const std::string& filename);
 
  public:
      VolumeGroup(DataStore *resolver) : resolver(resolver) {}
@@ -21,6 +26,13 @@ namespace aff4 {
      void AddVolume(AFF4Flusher<AFF4Volume> &&volume);
 
      AFF4Status GetStream(URN segment_urn, AFF4Flusher<AFF4Stream> &result);
+     
+     void AddSearchPath(std::string path);
+     void RemoveSearchPath(std::string path);
+     
+     AFF4Status LocateAndAdd(URN& urn);
+     void ScanForAFF4Volumes(const std::string& path);
+     
  };
 
 } // namespace aff4

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -737,6 +737,7 @@ AFF4Status ZipFileSegment::Flush() {
 
             RETURN_IF_ERROR(zip_info->WriteFileHeader(*backing_store));
             RETURN_IF_ERROR(backing_store->Write(cdata));
+            RETURN_IF_ERROR(zip_info->WriteDataDescriptor(*backing_store));
 
             // Compression method not known - ignore and store uncompressed.
         } else {
@@ -744,6 +745,7 @@ AFF4Status ZipFileSegment::Flush() {
 
             RETURN_IF_ERROR(zip_info->WriteFileHeader(*backing_store));
             RETURN_IF_ERROR(backing_store->Write(buffer));
+            RETURN_IF_ERROR(zip_info->WriteDataDescriptor(*backing_store));
         }
 
         // Replace ourselves in the members map.

--- a/aff4/zip.h
+++ b/aff4/zip.h
@@ -312,6 +312,10 @@ class ZipFile: public AFF4Volume {
         AFF4Flusher<AFF4Stream> &&backing_stream,
         AFF4Flusher<AFF4Volume> &result);
 
+    static std::string GetResourceID(
+        std::string& filename, 
+        std::shared_ptr<spdlog::logger> logger);
+    
     // Generic volume interface.
     AFF4Status CreateMemberStream(
         URN segment_urn,


### PR DESCRIPTION
This patch fixes building on current MacOS and adds support for automatically loading dependent striped image containers that are stored in the same folder as a container that has been opened. 