### PR TITLE
Support deflate compression

### DIFF
--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -65,8 +65,12 @@ namespace aff4 {
 // Compression methods we support.
 AFF4Status CompressZlib_(const char* data, size_t length, std::string* output);
 AFF4Status DeCompressZlib_(const char* data, size_t length, std::string* output);
+AFF4Status CompressDeflate_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressDeflate_(const char* data, size_t length, std::string* output);
 AFF4Status CompressSnappy_(const char* data, size_t length, std::string* output);
 AFF4Status DeCompressSnappy_(const char* data, size_t length, std::string* output);
+AFF4Status CompressLZ4_(const char* data, size_t length, std::string* output);
+AFF4Status DeCompressLZ4_(const char* data, size_t length, std::string* output);
 
 
 // This is the type written to the map stream in this exact binary layout.
@@ -144,7 +148,7 @@ class AFF4Image: public AFF4Stream {
     AFF4Status SwitchVolume(AFF4Volume *volume) override;
 
     // Which compression should we use.
-    AFF4_IMAGE_COMPRESSION_ENUM compression = AFF4_IMAGE_COMPRESSION_ENUM_ZLIB;
+    AFF4_IMAGE_COMPRESSION_ENUM compression = AFF4_IMAGE_COMPRESSION_ENUM_DEFLATE;
 
     static AFF4Status NewAFF4Image(
         DataStore* resolver,

--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -619,16 +619,14 @@ AFF4Status BasicImager::handle_compression() {
     std::string compression_setting = GetArg<TCLAP::ValueArg<std::string>>(
                                           "compression")->getValue();
 
-    if (compression_setting == "zlib") {
-        compression = AFF4_IMAGE_COMPRESSION_ENUM_ZLIB;
+    if (compression_setting == "deflate") {
+        compression = AFF4_IMAGE_COMPRESSION_ENUM_DEFLATE;
     } else if (compression_setting == "snappy") {
         compression = AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY;
     } else if (compression_setting == "lz4") {
         compression = AFF4_IMAGE_COMPRESSION_ENUM_LZ4;
-
     } else if (compression_setting == "none") {
         compression = AFF4_IMAGE_COMPRESSION_ENUM_STORED;
-
     } else {
         resolver.logger->error("Unknown compression scheme {}", compression);
         return INVALID_INPUT;

--- a/aff4/libaff4.cc
+++ b/aff4/libaff4.cc
@@ -436,6 +436,8 @@ const char* AFF4StatusToString(AFF4Status status) {
 AFF4_IMAGE_COMPRESSION_ENUM CompressionMethodFromURN(URN method) {
     if (method.value == AFF4_IMAGE_COMPRESSION_ZLIB) {
         return AFF4_IMAGE_COMPRESSION_ENUM_ZLIB;
+    } else if (method.value == AFF4_IMAGE_COMPRESSION_DEFLATE) {
+        return AFF4_IMAGE_COMPRESSION_ENUM_DEFLATE;
     } else if (method.value == AFF4_IMAGE_COMPRESSION_SNAPPY) {
         return AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY;
     } else if (method.value == AFF4_IMAGE_COMPRESSION_SNAPPY2) {
@@ -455,6 +457,9 @@ URN CompressionMethodToURN(AFF4_IMAGE_COMPRESSION_ENUM method) {
     switch (method) {
         case AFF4_IMAGE_COMPRESSION_ENUM_ZLIB:
             return AFF4_IMAGE_COMPRESSION_ZLIB;
+
+        case AFF4_IMAGE_COMPRESSION_ENUM_DEFLATE:
+            return AFF4_IMAGE_COMPRESSION_DEFLATE;
 
         case AFF4_IMAGE_COMPRESSION_ENUM_SNAPPY:
             return AFF4_IMAGE_COMPRESSION_SNAPPY;


### PR DESCRIPTION
This patch adds support for deflate (instead of zlib) compression, as that's what's standardized.  Zlib compression is still available for reading.