### PR TITLE
Add lexicon for standard hashes

### DIFF
--- a/aff4/lexicon.inc
+++ b/aff4/lexicon.inc
@@ -209,3 +209,14 @@ LEXICON_DEFINE(AFF4_DIRECTORY_TYPE, "http://aff4.org/Schema#directory");
 // between the URN and the filename. This attribute stores the _relative_ path
 // of the filename for the member URN relative to the container's path.
 LEXICON_DEFINE(AFF4_DIRECTORY_CHILD_FILENAME, "http://aff4.org/Schema#directory/filename");
+
+// Cryptographic Hashing
+
+LEXICON_DEFINE(AFF4_HASH_TYPE, "http://aff4.org/Schema#hash");
+
+LEXICON_DEFINE(AFF4_HASH_MD5, "http://aff4.org/Schema#MD5");
+LEXICON_DEFINE(AFF4_HASH_SHA1, "http://aff4.org/Schema#SHA1");
+LEXICON_DEFINE(AFF4_HASH_SHA256, "http://aff4.org/Schema#SHA256");
+LEXICON_DEFINE(AFF4_HASH_SHA512, "http://aff4.org/Schema#SHA512");
+LEXICON_DEFINE(AFF4_HASH_BLAKE2B, "http://aff4.org/Schema#blake2b");
+

--- a/aff4/rdf.cc
+++ b/aff4/rdf.cc
@@ -118,6 +118,93 @@ raptor_term* XSDString::GetRaptorTerm(raptor_world* world) const {
     return result;
 }
 
+raptor_term* MD5Hash::GetRaptorTerm(raptor_world* world) const {
+    std::string value_string(SerializeToString());
+    raptor_uri* uri = raptor_new_uri(
+        world, (const unsigned char*)AFF4_HASH_MD5);
+
+    raptor_term* result= raptor_new_term_from_counted_literal(
+                             world,
+                             (const unsigned char*)value_string.c_str(),
+                             value_string.size(),
+                             uri,
+                             nullptr, 0);
+
+    raptor_free_uri(uri);
+
+    return result;
+}
+
+raptor_term* SHA1Hash::GetRaptorTerm(raptor_world* world) const {
+    std::string value_string(SerializeToString());
+    raptor_uri* uri = raptor_new_uri(
+        world, (const unsigned char*)AFF4_HASH_SHA1);
+
+    raptor_term* result= raptor_new_term_from_counted_literal(
+                             world,
+                             (const unsigned char*)value_string.c_str(),
+                             value_string.size(),
+                             uri,
+                             nullptr, 0);
+
+    raptor_free_uri(uri);
+
+    return result;
+}
+
+raptor_term* SHA256Hash::GetRaptorTerm(raptor_world* world) const {
+    std::string value_string(SerializeToString());
+    raptor_uri* uri = raptor_new_uri(
+        world, (const unsigned char*)AFF4_HASH_SHA256);
+
+    raptor_term* result= raptor_new_term_from_counted_literal(
+                             world,
+                             (const unsigned char*)value_string.c_str(),
+                             value_string.size(),
+                             uri,
+                             nullptr, 0);
+
+    raptor_free_uri(uri);
+
+    return result;
+}
+
+raptor_term* SHA512Hash::GetRaptorTerm(raptor_world* world) const {
+    std::string value_string(SerializeToString());
+    raptor_uri* uri = raptor_new_uri(
+        world, (const unsigned char*)AFF4_HASH_SHA512);
+
+    raptor_term* result= raptor_new_term_from_counted_literal(
+                             world,
+                             (const unsigned char*)value_string.c_str(),
+                             value_string.size(),
+                             uri,
+                             nullptr, 0);
+
+    raptor_free_uri(uri);
+
+    return result;
+}
+
+raptor_term* Blake2BHash::GetRaptorTerm(raptor_world* world) const {
+    std::string value_string(SerializeToString());
+    raptor_uri* uri = raptor_new_uri(
+        world, (const unsigned char*)AFF4_HASH_BLAKE2B);
+
+    raptor_term* result= raptor_new_term_from_counted_literal(
+                             world,
+                             (const unsigned char*)value_string.c_str(),
+                             value_string.size(),
+                             uri,
+                             nullptr, 0);
+
+    raptor_free_uri(uri);
+
+    return result;
+}
+
+
+
 std::string URN::Scheme() const {
     // We only support aff4 and file URNs:
     if (value.compare(0, strlen(AFF4_PREFIX), AFF4_PREFIX) == 0) {
@@ -507,5 +594,11 @@ static RDFValueRegistrar<XSDInteger> r3(XSDIntegerType);
 static RDFValueRegistrar<XSDInteger> r4(XSDIntegerTypeInt);
 static RDFValueRegistrar<XSDInteger> r5(XSDIntegerTypeLong);
 static RDFValueRegistrar<XSDBoolean> r6(XSDBooleanType);
+
+static RDFValueRegistrar<MD5Hash> r7(AFF4_HASH_MD5);
+static RDFValueRegistrar<SHA1Hash> r8(AFF4_HASH_SHA1);
+static RDFValueRegistrar<SHA256Hash> r9(AFF4_HASH_SHA256);
+static RDFValueRegistrar<SHA512Hash> r10(AFF4_HASH_SHA512);
+static RDFValueRegistrar<Blake2BHash> r11(AFF4_HASH_BLAKE2B);
 
 } // namespace aff4

--- a/aff4/rdf.h
+++ b/aff4/rdf.h
@@ -161,6 +161,38 @@ class XSDString: public RDFBytes {
     raptor_term* GetRaptorTerm(raptor_world* world) const;
 };
 
+// Hash types
+
+class MD5Hash : public XSDString {
+  public:
+    using XSDString::XSDString;
+    raptor_term* GetRaptorTerm(raptor_world* world) const;
+};
+
+class SHA1Hash : public XSDString {
+  public:
+    using XSDString::XSDString;
+    raptor_term* GetRaptorTerm(raptor_world* world) const;
+};
+
+class SHA256Hash : public XSDString {
+  public:
+    using XSDString::XSDString;
+    raptor_term* GetRaptorTerm(raptor_world* world) const;
+};
+
+class SHA512Hash : public XSDString {
+  public:
+    using XSDString::XSDString;
+    raptor_term* GetRaptorTerm(raptor_world* world) const;
+};
+
+class Blake2BHash : public XSDString {
+  public:
+    using XSDString::XSDString;
+    raptor_term* GetRaptorTerm(raptor_world* world) const;
+};
+
 
 /**
  * A XSDInteger stores an integer. We can parse xsd:integer, xsd:int and


### PR DESCRIPTION
This adds the lexicon required to read standard hash properties.  I'll be submitting an extension to the C bindings that adds the functionality to read hash properties from streams.  This is the first step.