### PR TITLE
Fixed issue where condition will always evaluate as true on some systems

### DIFF
--- a/aff4/aff4_imager_utils.cc
+++ b/aff4/aff4_imager_utils.cc
@@ -649,7 +649,7 @@ std::vector<std::string> BasicImager::GlobFilename(std::string glob) const {
     }
 
     WIN32_FIND_DATA ffd;
-    unsigned int found = glob.find_last_of("/\\");
+    const auto found = glob.find_last_of("/\\");
     std::string path = "";
 
     // The path before the last PATH_SEP


### PR DESCRIPTION
In some standard libraries `std::string::size_type` is not unsigned and `std::string::npos` is defined as a negative size.   In these cases, the  following conditional would always evaluate as true because of the type differences (mingw-w64 warning):

```    // The path before the last PATH_SEP
    if (found != std::string::npos) {
        path = glob.substr(0, found);
    }
```

 