### PR TITLE
Don't store AFF4_SEGMENT_FOR_URN for every zip segment.  

### DIFF
--- a/aff4/lexicon.inc
+++ b/aff4/lexicon.inc
@@ -27,10 +27,6 @@ LEXICON_DEFINE(BUILTIN_PREFIX, "builtin://");
 // object internally.
 LEXICON_DEFINE(AFF4_VOLATILE_NAMESPACE, "http://aff4.org/VolatileSchema#");
 
-// We just store the member_name -> URN mapping so we can ensure the
-// right member is opened.
-LEXICON_DEFINE(AFF4_SEGMENT_FOR_URN, "http://aff4.org/VolatileSchema#segment_for_urn");
-
 // Commonly used RDF types.
 LEXICON_DEFINE(URNType, "URN");
 LEXICON_DEFINE(XSDStringType, "http://www.w3.org/2001/XMLSchema#string");

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -355,13 +355,6 @@ AFF4Status ZipFile::parse_cd() {
             resolver->Set(member_urn, AFF4_TYPE, new URN(AFF4_ZIP_SEGMENT_TYPE));
             resolver->Set(member_urn, AFF4_STORED, new URN(urn));
 
-            // Store the URL->member name mapping so we can open the
-            // right member if the URN is opened. This is because the
-            // member_name_for_urn and urn_from_member_name are not
-            // exactly symmetrical in all cases.
-            resolver->Set(member_urn, AFF4_SEGMENT_FOR_URN, new XSDString(
-                              zip_info->filename));
-
             members[zip_info->filename] = std::move(zip_info);
         }
 


### PR DESCRIPTION
Currently when loading maps a  AFF4_SEGMENT_FOR_URN property is added for each and every zip segment.  This property is never read anywhere else in the library and removing it speeds up image loading significantly on images that have many zip segments.