### PR TITLE
Optimize load times by defaulting object types to zip segment

### DIFF
--- a/aff4/data_store.cc
+++ b/aff4/data_store.cc
@@ -36,6 +36,12 @@ bool DataStore::ShouldSuppress(const URN& subject,
                                const URN& predicate,
                                const std::string& value) {
     URN type(AFF4_TYPE);
+
+    if (!HasURNWithAttribute(subject, type)) {
+        // This is assumed to be an object of type AFF4_ZIP_SEGMENT_TYPE
+        return true;
+    }
+
     if (predicate == AFF4_STORED &&
         (HasURNWithAttributeAndValue(
             subject, type, URN(AFF4_ZIP_SEGMENT_TYPE)) ||
@@ -396,6 +402,14 @@ AFF4Status MemoryDataStore::Get(const URN& urn, const URN& attribute,
 
     auto attribute_itr = urn_it->second.find(attribute.SerializeToString());
     if (attribute_itr == urn_it->second.end()) {
+        // Since the majority of AFF4 objects in practice are zip segments,
+        // as an optimization we don't store type attributes for these
+        // objects.  Instead, objects without type attriutes are assumed to
+        // be zip segments.
+        if (attribute == AFF4_TYPE) {
+            value.UnSerializeFromString(AFF4_ZIP_SEGMENT_TYPE);
+        }
+
         return NOT_FOUND;
     }
 
@@ -424,6 +438,14 @@ AFF4Status MemoryDataStore::Get(const URN& urn,
 
     auto attribute_itr = urn_it->second.find(attribute.SerializeToString());
     if (attribute_itr == urn_it->second.end()) {
+        // Since the majority of AFF4 objects in practice are zip segments,
+        // as an optimization we don't store type attributes for these
+        // objects.  Instead, objects without type attriutes are assumed to
+        // be zip segments.
+        if (attribute == AFF4_TYPE) {
+            values.emplace_back(new URN(AFF4_ZIP_SEGMENT_TYPE));
+            return STATUS_OK;
+        }
         return NOT_FOUND;
     }
 

--- a/aff4/zip.cc
+++ b/aff4/zip.cc
@@ -352,7 +352,6 @@ AFF4Status ZipFile::parse_cd() {
             // Store this information in the resolver. Ths allows segments to be
             // directly opened by URN.
             URN member_urn = urn_from_member_name(zip_info->filename, urn);
-            resolver->Set(member_urn, AFF4_TYPE, new URN(AFF4_ZIP_SEGMENT_TYPE));
             resolver->Set(member_urn, AFF4_STORED, new URN(urn));
 
             // Store the URL->member name mapping so we can open the
@@ -476,7 +475,6 @@ AFF4Status ZipFile::CreateMemberStream(
     URN segment_urn,
     AFF4Flusher<AFF4Stream> &result) {
 
-    resolver->Set(segment_urn, AFF4_TYPE, new URN(AFF4_ZIP_SEGMENT_TYPE));
     resolver->Set(segment_urn, AFF4_STORED, new URN(urn));
 
     auto new_obj = new ZipFileSegment(resolver);


### PR DESCRIPTION
In practice, the vast majority of AFF4 objects are zip segments.  This PR adds an optimization where by default AFF4_TYPE properties are assumed to be AFF4_ZIP_SEGMENT_TYPE if no other type is defined.  This prevents a map insertion for every single zip segment, which can drastically speed up image loading when dealing with images with large numbers of segments