### PR TITLE
Added missing header

### DIFF
--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -17,6 +17,7 @@
 #define LIBAFF4_C_H_
 
 #include <stdint.h>
+#include <unistd.h>
 
 /*
  * This is the C interface into libaff4.


### PR DESCRIPTION
On some systems, `ssize_t` and `size_t` aren't defined without `unistd.h`