### PR TITLE
C API log verbosity cleanup

### DIFF
--- a/aff4/libaff4-c.cc
+++ b/aff4/libaff4-c.cc
@@ -79,14 +79,14 @@ public:
 };
 
 
-std::shared_ptr<spdlog::logger> setup_c_api_logger() {
+static std::shared_ptr<spdlog::logger> setup_c_api_logger() {
     spdlog::drop(aff4::LOGGER);
     auto logger = spdlog::create(aff4::LOGGER, std::make_shared<LogSink>());
     logger->set_level(spdlog::level::err);
     return logger;
 }
 
-std::shared_ptr<spdlog::logger> get_c_api_logger() {
+static std::shared_ptr<spdlog::logger> get_c_api_logger() {
     static std::shared_ptr<spdlog::logger> the_logger = setup_c_api_logger();
     return the_logger;
 }
@@ -103,24 +103,31 @@ struct AFF4_Handle {
     {}
 };
 
-spdlog::level::level_enum enum_for_level(unsigned int level) {
+static spdlog::level::level_enum enum_for_level(AFF4_LOG_LEVEL level) {
     switch (level) {
-    case 0:
-        return spdlog::level::trace;
-    case 1:
-        return spdlog::level::debug;
-    case 2:
-        return spdlog::level::info;
-    case 3:
-        return spdlog::level::warn;
-    default:
-        return spdlog::level::err;
+        case AFF4_LOG_LEVEL_TRACE:
+            return spdlog::level::trace;
+        case AFF4_LOG_LEVEL_DEBUG:
+            return spdlog::level::debug;
+        case AFF4_LOG_LEVEL_INFO:
+            return spdlog::level::info;
+        case AFF4_LOG_LEVEL_WARNING:
+            return spdlog::level::warn;
+        case AFF4_LOG_LEVEL_ERROR:
+            return spdlog::level::err;
+        case AFF4_LOG_LEVEL_CRITICAL:
+            return spdlog::level::critical;
+        case AFF4_LOG_LEVEL_OFF:
+            return spdlog::level::off;
     }
+
+    // Should be unreachable
+    return spdlog::level::err;
 }
 
 extern "C" {
 
-void AFF4_set_verbosity(unsigned int level) {
+void AFF4_set_verbosity(AFF4_LOG_LEVEL level) {
     get_c_api_logger()->set_level(enum_for_level(level));
 }
 

--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -51,19 +51,24 @@ typedef struct AFF4_Message {
 void AFF4_free_messages(AFF4_Message* msg);
 
 /**
+ * Log verbosity levels
+ */
+typedef enum {
+    AFF4_LOG_LEVEL_TRACE,
+    AFF4_LOG_LEVEL_DEBUG,
+    AFF4_LOG_LEVEL_INFO,
+    AFF4_LOG_LEVEL_WARNING,
+    AFF4_LOG_LEVEL_ERROR,
+    AFF4_LOG_LEVEL_CRITICAL,
+    AFF4_LOG_LEVEL_OFF
+} AFF4_LOG_LEVEL;
+
+/**
  * Set the verbosity level for logging.
- * Levels are:
- *    0 trace
- *    1 debug
- *    2 info
- *    3 warning
- *    4 error
- *    5 critical
- *    6 off
  *
  * @param level The verbosity level
  */
-void AFF4_set_verbosity(unsigned int level);
+void AFF4_set_verbosity(AFF4_LOG_LEVEL level);
 
 typedef struct AFF4_Handle AFF4_Handle;
 


### PR DESCRIPTION
This PR just cleans up the C API log verbosity interface a bit to make it clearer which levels are being used.