### PR TITLE
Cleanup unused and incomplete AFF4StdImage class

### DIFF
--- a/aff4/aff4_image.h
+++ b/aff4/aff4_image.h
@@ -196,31 +196,6 @@ class AFF4Image: public AFF4Stream {
     using AFF4Stream::Write;
 };
 
-
-// The AFF4 Standard specifies an "AFF4 Image" as an abstract
-// container for image related properties. It is not actually a
-// concrete stream but it refers to a storage stream using its
-// aff4:dataStream property.
-
-// We implement a read-only stream which delegates reads to the
-// underlying storage stream. This is necessary in order to be able to
-// open such a stream for reading.
-
-// Note that to create such a stream, you can simply set the
-// aff4:dataStream to a concerete Map or ImageStream.
- class AFF4StdImage : public AFF4Stream {
- public:
-     AFF4StdImage(DataStore* resolver, URN urn): AFF4Stream(resolver, urn) {}
-     explicit AFF4StdImage(DataStore* resolver): AFF4Stream(resolver) {}
-
-    AFF4Status ReadBuffer(char* data, size_t* length) override;
-
- protected:
-    URN delegate;
-};
-
-
-
 extern void aff4_image_init();
 
 } // namespace aff4


### PR DESCRIPTION
This class is no longer used and you get link errors if you try to use it because it's not completely defined.