### PR TITLE
Added (optional) handle cache to C API

### DIFF
--- a/aff4/libaff4-c.h
+++ b/aff4/libaff4-c.h
@@ -71,6 +71,20 @@ typedef enum {
  */
 void AFF4_set_verbosity(AFF4_LOG_LEVEL level);
 
+/**
+ * Set the maximum number of handles to be retained in a cache for reuse.
+ * By default no handles are cached.
+ *
+ * @param n The number of handles to cache
+ */
+void AFF4_set_handle_cache_size(size_t n);
+
+/**
+ * Empties the handle cache, freeing all cached handles.
+ * This does not affect the cache size.
+ */
+void AFF4_clear_handle_cache();
+
 typedef struct AFF4_Handle AFF4_Handle;
 
 /**


### PR DESCRIPTION
Our application frequently opens handles and closes them, and thus benefits greatly from a simple cache to not have to parse everything when reopening a handle.  I figure this could be generally useful to others.

This PR adds an optional thread-safe cache with the functionality of setting how many handles are cached and clearing the cache on demand.  By default no handles are cached and the library behaves as normal.