### PR TITLE
Modernize creation and ownership transfer of AFF4Flusher

### DIFF
--- a/aff4/aff4_directory.cc
+++ b/aff4/aff4_directory.cc
@@ -34,7 +34,7 @@ AFF4Status AFF4Directory::NewAFF4Directory(
     RETURN_IF_ERROR(AFF4Directory::NewAFF4Directory(
                         resolver, root_path, truncate, new_obj));
 
-    result.reset(new_obj.release());
+    result = std::move(new_obj);
 
     return STATUS_OK;
 }
@@ -44,7 +44,7 @@ AFF4Status AFF4Directory::NewAFF4Directory(
     bool truncate,
     AFF4Flusher<AFF4Directory> &result) {
 
-    AFF4Flusher<AFF4Directory> new_obj(new AFF4Directory(resolver));
+    auto new_obj = make_flusher<AFF4Directory>(resolver);
     new_obj->root_path = root_path;
 
     // If mode is truncate we need to clear the directory.
@@ -72,7 +72,7 @@ AFF4Status AFF4Directory::NewAFF4Directory(
 
     resolver->Set(new_obj->urn, AFF4_STORED, new URN(URN::NewURNFromFilename(root_path, true)));
 
-    result.swap(new_obj);
+    result = std::move(new_obj);
 
     return STATUS_OK;
 }
@@ -112,7 +112,7 @@ AFF4Status AFF4Directory::CreateMemberStream(
 
     MarkDirty();
 
-    result.reset(child_fd.release());
+    result = std::move(child_fd);
 
     return STATUS_OK;
 }
@@ -143,7 +143,7 @@ AFF4Status AFF4Directory::OpenMemberStream(
 
     child_fd->urn = child;
 
-    result.reset(child_fd.release());
+    result = std::move(child_fd);
 
     return STATUS_OK;
 }
@@ -152,7 +152,7 @@ AFF4Status AFF4Directory::OpenAFF4Directory(
     DataStore *resolver, std::string dirname,
     AFF4Flusher<AFF4Directory> &result) {
 
-    AFF4Flusher<AFF4Directory> new_obj(new AFF4Directory(resolver));
+    auto new_obj = make_flusher<AFF4Directory>(resolver);
     new_obj->root_path = dirname;
 
     AFF4Flusher<FileBackedObject> desc;
@@ -170,7 +170,7 @@ AFF4Status AFF4Directory::OpenAFF4Directory(
                         dirname + PATH_SEP_STR + AFF4_CONTAINER_INFO_TURTLE,
                         "read", turtle_stream));
 
-    result.swap(new_obj);
+    result = std::move(new_obj);
 
     return resolver->LoadFromTurtle(*turtle_stream);
 }

--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -46,7 +46,7 @@ FileBackedObject implementation.
      AFF4Flusher<FileBackedObject> file;
      RETURN_IF_ERROR(NewFileBackedObject(resolver, filename, mode, file));
 
-     result.reset(file.release());
+     result = std::move(file);
 
      return STATUS_OK;
  }
@@ -168,7 +168,7 @@ AFF4Status FileBackedObject::ReadBuffer(char * data, size_t * length) {
      std::string filename,
      std::string mode,
      AFF4Flusher<FileBackedObject> &result) {
-     auto new_object = AFF4Flusher<FileBackedObject>(new FileBackedObject(resolver));
+     auto new_object = make_flusher<FileBackedObject>(resolver);
      new_object->urn = URN::NewURNFromFilename(filename, false);
 
     std::vector<std::string> directory_components = split(filename, PATH_SEP);
@@ -241,7 +241,7 @@ AFF4Status FileBackedObject::ReadBuffer(char * data, size_t * length) {
         }
     }
 
-    result.swap(new_object);
+    result = std::move(new_object);
 
     return STATUS_OK;
 }
@@ -327,7 +327,7 @@ FileBackedObject::~FileBackedObject() {
      std::string mode,
      AFF4Flusher<FileBackedObject> &result
  ) {
-     auto new_object = AFF4Flusher<FileBackedObject>(new FileBackedObject(resolver));
+     auto new_object = make_flusher<FileBackedObject>(resolver);
      new_object->urn = URN::NewURNFromFilename(filename, false);
 
      std::vector<std::string> directory_components = split(filename, PATH_SEP);
@@ -375,7 +375,7 @@ FileBackedObject::~FileBackedObject() {
         new_object->properties.seekable = false;
     }
 
-     result.swap(new_object);
+     result = std::move(new_object);
 
      return STATUS_OK;
  }
@@ -442,7 +442,7 @@ AFF4Status AFF4Stdout::NewAFF4Stdout(
         DataStore *resolver,
         AFF4Flusher<AFF4Stream> &result) {
 
-    AFF4Flusher<AFF4Stdout> new_object(new AFF4Stdout(resolver));
+    auto new_object = make_flusher<AFF4Stdout>(resolver);
 
     new_object->properties.seekable = false;
     new_object->properties.writable = true;
@@ -458,7 +458,7 @@ AFF4Status AFF4Stdout::NewAFF4Stdout(
     new_object->fd = STDOUT_FILENO;
 #endif
 
-    result.reset(new_object.release());
+    result = std::move(new_object);
 
     return STATUS_OK;
 }

--- a/aff4/aff4_image.cc
+++ b/aff4/aff4_image.cc
@@ -390,7 +390,7 @@ AFF4Status AFF4Image::OpenAFF4Image(
     VolumeGroup *volumes,
     AFF4Flusher<AFF4Image> &result) {
 
-    auto new_obj = AFF4Flusher<AFF4Image>(new AFF4Image(resolver));
+    auto new_obj = make_flusher<AFF4Image>(resolver);
     new_obj->urn.Set(image_urn);
     new_obj->volumes = volumes;
 
@@ -462,7 +462,7 @@ AFF4Status AFF4Image::OpenAFF4Image(
         }
     }
 
-    result.swap(new_obj);
+    result = std::move(new_obj);
 
     return STATUS_OK;
 }
@@ -478,7 +478,7 @@ AFF4Status AFF4Image::NewAFF4Image(
         AFF4Image::NewAFF4Image(
             resolver, image_urn, volume, image));
 
-    result.reset(image.release());
+    result = std::move(image);
 
     return STATUS_OK;
 }
@@ -490,7 +490,7 @@ AFF4Status AFF4Image::NewAFF4Image(
     AFF4Volume *volume,
     AFF4Flusher<AFF4Image> &result) {
 
-    auto new_obj = AFF4Flusher<AFF4Image>(new AFF4Image(resolver));
+    auto new_obj = make_flusher<AFF4Image>(resolver);
     new_obj->urn = image_urn;
     new_obj->current_volume = volume;
 
@@ -501,7 +501,7 @@ AFF4Status AFF4Image::NewAFF4Image(
         resolver->Set(image_urn, AFF4_STREAM_SIZE, new XSDInteger((uint64_t)0));
     }
 
-    new_obj.swap(result);
+    new_obj = std::move(result);
 
     return STATUS_OK;
 }

--- a/aff4/aff4_map.cc
+++ b/aff4/aff4_map.cc
@@ -45,7 +45,7 @@ AFF4Status AFF4Map::NewAFF4Map(
         return INVALID_INPUT;
     }
 
-    AFF4Flusher<AFF4Map> new_object(new AFF4Map(resolver));
+    auto new_object = make_flusher<AFF4Map>(resolver);
     new_object->urn = object_urn;
 
     // If callers did not provide a data stream we create a default
@@ -69,7 +69,7 @@ AFF4Status AFF4Map::NewAFF4Map(
     resolver->Set(object_urn, AFF4_STORED, new URN(volume->urn));
     new_object->current_volume = volume;
 
-    result.reset(new_object.release());
+    result = std::move(new_object);
 
     return STATUS_OK;
 }
@@ -78,7 +78,7 @@ AFF4Status AFF4Map::OpenAFF4Map(
     DataStore* resolver, const URN& object_urn,
     VolumeGroup *volumes, AFF4Flusher<AFF4Map> &map_obj) {
 
-    map_obj.reset(new AFF4Map(resolver));
+    map_obj = make_flusher<AFF4Map>(resolver);
     map_obj->urn = object_urn;
     map_obj->volumes = volumes;
 

--- a/aff4/data_store.h
+++ b/aff4/data_store.h
@@ -59,6 +59,13 @@ template<typename AFF4ObjectType>
 using AFF4Flusher = std::unique_ptr<AFF4ObjectType, AFF4Flusher_deleter>;
 
 
+// Constructs an AFF4 Object and wraps it in a AFF4Flusher
+template<typename AFF4ObjectType, typename ...Args>
+AFF4Flusher<AFF4ObjectType> make_flusher(Args && ...args) {
+    return AFF4Flusher<AFF4ObjectType>(new AFF4ObjectType(std::forward<Args>(args)...));
+}
+
+
 /**
  * @file   data_store.h
  * @author scudette <scudette@google.com>

--- a/aff4/volume_group.cc
+++ b/aff4/volume_group.cc
@@ -28,7 +28,7 @@ AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &resul
                     AFF4Image::OpenAFF4Image(
                         resolver, stream_urn, this, image_stream));
 
-                result.reset(image_stream.release());
+                result = std::move(image_stream);
 
                 resolver->logger->debug("Openning {} as type {}",
                                         stream_urn, type_str);
@@ -64,7 +64,7 @@ AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &resul
                     AFF4Map::OpenAFF4Map(
                         resolver, stream_urn, this, map_stream));
 
-                result.reset(map_stream.release());
+                result = std::move(map_stream);
                 resolver->logger->debug("Openning {} as type {}",
                                         stream_urn, type_str);
 
@@ -90,19 +90,19 @@ AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &resul
 
     // Handle symbolic streams now.
     if (stream_urn == AFF4_IMAGESTREAM_ZERO) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0));
+        result = make_flusher<AFF4SymbolicStream>(resolver, stream_urn, 0);
         return STATUS_OK;
     }
     if (stream_urn == AFF4_IMAGESTREAM_FF) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, 0xff));
+        result = make_flusher<AFF4SymbolicStream>(resolver, stream_urn, 0xff);
         return STATUS_OK;
     }
     if (stream_urn == AFF4_IMAGESTREAM_UNKNOWN) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNKNOWN"));
+        result = make_flusher<AFF4SymbolicStream>(resolver, stream_urn, "UNKNOWN");
         return STATUS_OK;
     }
     if (stream_urn == AFF4_IMAGESTREAM_UNREADABLE) {
-        result.reset(new AFF4SymbolicStream(resolver, stream_urn, "UNREADABLEDATA"));
+        result = make_flusher<AFF4SymbolicStream>(resolver, stream_urn, "UNREADABLEDATA");
         return STATUS_OK;
     }
 
@@ -111,7 +111,7 @@ AFF4Status VolumeGroup::GetStream(URN stream_urn, AFF4Flusher<AFF4Stream> &resul
             "%s%02X", AFF4_IMAGESTREAM_SYMBOLIC_PREFIX, i);
 
         if (stream_urn == urn) {
-            result.reset(new AFF4SymbolicStream(resolver, stream_urn, i));
+            result = make_flusher<AFF4SymbolicStream>(resolver, stream_urn, i);
             return STATUS_OK;
         }
     }


### PR DESCRIPTION
This is a bit of cleanup and modernization.  This PR does two things

1) It creates a make_flusher function to create AFF4Flusher smart pointers (like C++14's make_unique)
2) It standardizes the way that pointer ownership is transferred in the codebase.