### PR TITLE
Allows the aff4_file cache to be disabled.

### DIFF
--- a/aff4/aff4_file.cc
+++ b/aff4/aff4_file.cc
@@ -206,6 +206,10 @@ AFF4Status FileBackedObject::ReadBuffer(char * data, size_t * length) {
         FILE_ATTRIBUTE_NORMAL,
         nullptr);
 
+    // Set defaults for file cache.
+    new_object->cache_block_size = 2*1024*1024;  // 2 MiB
+    new_object->cache_block_limit = 32;  // 32 MiB total
+
     if (new_object->fd == INVALID_HANDLE_VALUE) {
         resolver->logger->error(
             "Cannot open file {} : {}", filename,

--- a/aff4/aff4_file.h
+++ b/aff4/aff4_file.h
@@ -50,6 +50,8 @@ class FileBackedObject: public AFF4Stream {
     explicit FileBackedObject(DataStore* resolver): AFF4Stream(resolver), fd(0){}
     virtual ~FileBackedObject();
 
+
+
     AFF4Status ReadBuffer(char* data, size_t *length) override;
     AFF4Status Write(const char* data, size_t length) override;
 
@@ -63,8 +65,8 @@ class FileBackedObject: public AFF4Stream {
     int fd;
 #endif
 
-    static constexpr size_t cache_block_size = 2 * 1024 * 1024; // 2 MiB
-    static constexpr size_t cache_block_limit = 32; // 32 MiB total
+    size_t cache_block_size;
+    size_t cache_block_limit;
 
   private:
     // Read buffer, bypassing cache

--- a/docker/Makefile-deps
+++ b/docker/Makefile-deps
@@ -1,6 +1,6 @@
 # This makefile fetches and builds all of the dependencies for aff4.
 
-CONCURRENCY=14
+CONCURRENCY=4
 ZLIB_VERSION=1.2.11.dfsg
 ZLIB_SRC_PATH=zlib-${ZLIB_VERSION}
 RAPTOR_VERSION=2.0.14

--- a/tools/pmem/win_pmem.cc
+++ b/tools/pmem/win_pmem.cc
@@ -160,6 +160,10 @@ AFF4Status WinPmemImager::GetMemoryInfo(PmemMemoryInfo *info) {
           resolver.logger->error("Cannot open device {}", device_path);
           return IO_ERROR;
       }
+
+      // We do not want to cache anything here since we implement
+      // paged reading to work around VSM IO Errors.
+      device->cache_block_size = 0;
   }
 
   // Set the acquisition mode.
@@ -499,6 +503,13 @@ AFF4Status WinPmemImager::WriteMapObject_(const URN &map_urn) {
 AFF4Status WinPmemImager::ImagePhysicalMemory() {
   AFF4Status res;
   std::string format = GetArg<TCLAP::ValueArg<std::string>>("format")->getValue();
+
+  std::string volume_format = GetArg<TCLAP::ValueArg<std::string>>(
+      "volume_format")->getValue();
+
+  if (volume_format == "raw" && format == "map") {
+      format = "raw";
+  }
 
   // First ensure that the driver is loaded.
   res = InstallDriver();


### PR DESCRIPTION
The file cache failes to read the 2mb page if any page within it has
an IO Error and therefore breaks VSM support.