### PR TITLE
CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Run on windows 2019
-        run:
+        run: |
          curl -OL https://github.com/Velocidex/c-aff4/releases/download/v3.3.rc3/winpmem_v3.3.rc3.exe
          ./winpmem_v3.3.rc3.exe --output memdump.raw --format raw --volume_format raw
          dir
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Run on windows 2022
-        run:
+        run: |
          curl -OL https://github.com/Velocidex/c-aff4/releases/download/v3.3.rc3/winpmem_v3.3.rc3.exe
          ./winpmem_v3.3.rc3.exe --output memdump.raw --format raw --volume_format raw
          dir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  #manually trigger runs
+  workflow_dispatch:
+
+jobs:
+   build_2019:
+    runs-on: windows-2019
+    steps:
+      - name: Run on windows 2019
+        run:
+         curl -OL https://github.com/Velocidex/c-aff4/releases/download/v3.3.rc3/winpmem_v3.3.rc3.exe
+         ./winpmem_v3.3.rc3.exe --output memdump.raw --format raw --volume_format raw
+         dir
+         
+   build_2022:
+    runs-on: windows-2022
+    steps:
+      - name: Run on windows 2022
+        run:
+         curl -OL https://github.com/Velocidex/c-aff4/releases/download/v3.3.rc3/winpmem_v3.3.rc3.exe
+         ./winpmem_v3.3.rc3.exe --output memdump.raw --format raw --volume_format raw
+         dir


### PR DESCRIPTION
CI tests for Windows server 2019 and 2022. Demonstrates the failure on 2022. Set to run manually for safety/annoyance reasons.